### PR TITLE
Support Mac OS X build

### DIFF
--- a/src/resource/shader.h
+++ b/src/resource/shader.h
@@ -8,7 +8,11 @@
 #ifndef SHADER_H
 #define SHADER_H
 
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
 
 #define DELIM "%% -- FRAG"
 #define DELIM_SIZE 10

--- a/src/taiseigl.c
+++ b/src/taiseigl.c
@@ -7,10 +7,12 @@
 
 #include "taiseigl.h"
 
+#ifndef __APPLE__
 #ifdef __WIN32__
 // #include <GL/wgl.h>
 #else
 #include <GL/glx.h>
+#endif
 #endif
 
 #include <string.h>
@@ -18,6 +20,7 @@
 
 int tgl_ext[_TGLEXT_COUNT];
 
+#ifndef __APPLE__
 typedef void (*GLFuncPtr)(void);
 GLFuncPtr get_proc_address(char *name) {
 #ifdef __WIN32__
@@ -26,6 +29,7 @@ GLFuncPtr get_proc_address(char *name) {
 	return glXGetProcAddress((GLubyte *)name);
 #endif
 }
+#endif
 
 
 void check_gl_extensions(void) {
@@ -53,6 +57,7 @@ void load_gl_functions(void) {
 	glBlendEquation = (PFNGLBLENDEQUATIONPROC)get_proc_address("glBlendEquation");
 #endif
 	
+#ifndef __APPLE__
 	glBlendFuncSeparate = (PFNGLBLENDFUNCSEPARATEPROC)get_proc_address("glBlendFuncSeparate");
 	glDrawArraysInstanced = (PFNGLDRAWARRAYSINSTANCEDPROC)get_proc_address("glDrawArraysInstanced");
 
@@ -98,4 +103,5 @@ void load_gl_functions(void) {
 	glUniform2fv = (PFNGLUNIFORM2FVPROC)get_proc_address("glUniform2fv");
 	glUniform3fv = (PFNGLUNIFORM3FVPROC)get_proc_address("glUniform3fv");
 	glUniform4fv = (PFNGLUNIFORM4FVPROC)get_proc_address("glUniform4fv");
+#endif
 }

--- a/src/taiseigl.h
+++ b/src/taiseigl.h
@@ -8,9 +8,15 @@
 #ifndef TAISEIGL_H
 #define TAISEIGL_H
 
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#include <OpenGL/glu.h>
+#include <OpenGL/glext.h>
+#else
 #include <GL/gl.h>
 #include <GL/glu.h>
 #include <GL/glext.h>
+#endif
 
 enum {
 	TGLEXT_draw_instanced = 0,
@@ -27,6 +33,7 @@ PFNGLACTIVETEXTUREPROC glActiveTexture;
 PFNGLBLENDEQUATIONPROC glBlendEquation;
 #endif
 
+#ifndef __APPLE__
 PFNGLBLENDFUNCSEPARATEPROC glBlendFuncSeparate;
 PFNGLDRAWARRAYSINSTANCEDPROC glDrawArraysInstanced;
 
@@ -72,5 +79,6 @@ PFNGLUNIFORM4IPROC glUniform4i;
 PFNGLUNIFORM2FVPROC glUniform2fv;
 PFNGLUNIFORM3FVPROC glUniform3fv;
 PFNGLUNIFORM4FVPROC glUniform4fv;
+#endif
 
 #endif


### PR DESCRIPTION
Here is a small set of changes that could make taisei run on Mac OS X with libraries built with [Homebrew](http://brew.sh/).

- Use bundled `OpenGL.framework`
  - `OpenGL/` instead of `GL/` for headers
  - No need for importing GL functions (no `glXGetProcAddress` from `glx.h`)

Yet, it still gives me no sound though. Probably something goes wrong with `OpenAL.framework` (or `openal-soft`) and `freealut` packages.