### PR TITLE
Integral complex constants changed to float

### DIFF
--- a/src/enemy.c
+++ b/src/enemy.c
@@ -142,8 +142,8 @@ void EnemyFlareShrink(Projectile *p, int t) {
 
 void BigFairy(Enemy *e, int t) {
 	if(!(t % 5)) {
-		complex offset = (frand()-0.5)*30 + (frand()-0.5)*20I;
-		create_particle3c("lasercurve", offset, rgb(0,0.2,0.3), EnemyFlareShrink, enemy_flare, 50, (-50I-offset)/50.0, add_ref(e));
+		complex offset = (frand()-0.5)*30 + (frand()-0.5)*20.0I;
+		create_particle3c("lasercurve", offset, rgb(0,0.2,0.3), EnemyFlareShrink, enemy_flare, 50, (-50.0I-offset)/50.0, add_ref(e));
 	}
 	
 	glPushMatrix();

--- a/src/item.c
+++ b/src/item.c
@@ -63,7 +63,7 @@ void delete_items(void) {
 
 void move_item(Item *i) {
 	int t = global.frames - i->birthtime;
-	complex lim = 0 + 2I;
+	complex lim = 0 + 2.0I;
 	
 	if(i->auto_collect)	
 		i->pos -= (7+i->auto_collect)*cexp(I*carg(i->pos - global.plr.pos));

--- a/src/player.c
+++ b/src/player.c
@@ -203,7 +203,7 @@ void player_realdeath(Player *plr) {
 	create_item(plr->pos, 6-15*I, Power);
 	create_item(plr->pos, -6-15*I, Power);
 	
-	plr->pos = VIEWPORT_W/2 + VIEWPORT_H*I+30I;
+	plr->pos = VIEWPORT_W/2 + VIEWPORT_H*I+30.0I;
 	plr->recovery = -(global.frames + DEATH_DELAY + 150);
 
 	if(plr->bombs < PLR_START_BOMBS)
@@ -348,8 +348,8 @@ void player_applymovement(Player *plr) {
 	
 	complex direction = 0;
 	
-	if(up)		direction -= 1I;
-	if(down)	direction += 1I;
+	if(up)		direction -= 1.0I;
+	if(down)	direction += 1.0I;
 	if(left)	direction -= 1;
 	if(right)	direction += 1;
 	

--- a/src/plrmodes.c
+++ b/src/plrmodes.c
@@ -99,13 +99,13 @@ int youmu_slash(Enemy *e, int t) {
 		
 	FROM_TO(30, 60, 10) {
 		tsrand_fill(3);
-		create_particle1c("youmu_slice", VIEWPORT_W/2.0 - 150 + 100*_i + VIEWPORT_H/2.0*I - 10-10I + 20*afrand(0)+20I*afrand(1), NULL, Slice, timeout, 200)->angle = -10.0+20.0*afrand(2);
+		create_particle1c("youmu_slice", VIEWPORT_W/2.0 - 150 + 100*_i + VIEWPORT_H/2.0*I - 10-10.0I + 20*afrand(0)+20.0I*afrand(1), NULL, Slice, timeout, 200)->angle = -10.0+20.0*afrand(2);
 	}
 	
 	FROM_TO(40,200,1)
 		if(frand() > 0.7) {
 			tsrand_fill(6);
-			create_particle2c("blast", VIEWPORT_W*afrand(0) + (VIEWPORT_H+50)*I, rgb(afrand(1),afrand(2),afrand(3)), Shrink, timeout_linear, 80, 3*(1-2.0*afrand(4))-14I+afrand(5)*2I);
+			create_particle2c("blast", VIEWPORT_W*afrand(0) + (VIEWPORT_H+50)*I, rgb(afrand(1),afrand(2),afrand(3)), Shrink, timeout_linear, 80, 3*(1-2.0*afrand(4))-14.0I+afrand(5)*2.0I);
 		}
 		
 	int tpar = 30;
@@ -114,7 +114,7 @@ int youmu_slash(Enemy *e, int t) {
 	
 	if(t < creal(e->args[0])-60 && frand() > 0.2) {
 		tsrand_fill(3);
-		create_particle2c("smoke", VIEWPORT_W*afrand(0) + (VIEWPORT_H+100)*I, rgba(0.4,0.4,0.4,afrand(1)*0.2 - 0.2 + 0.6*(tpar/30.0)), PartDraw, spin, 300, -7I+afrand(2)*1I);		
+		create_particle2c("smoke", VIEWPORT_W*afrand(0) + (VIEWPORT_H+100)*I, rgba(0.4,0.4,0.4,afrand(1)*0.2 - 0.2 + 0.6*(tpar/30.0)), PartDraw, spin, 300, -7.0I+afrand(2)*1.0I);		
 	}
 	return 1;
 }
@@ -124,7 +124,7 @@ int youmu_slash(Enemy *e, int t) {
 void YoumuOppositeMyon(Enemy *e, int t) {
 	complex pos = e->pos;
 	
-	create_particle2c("flare", pos, NULL, Shrink, timeout, 10, -e->pos+10I);
+	create_particle2c("flare", pos, NULL, Shrink, timeout, 10, -e->pos+10.0I);
 }
 
 int youmu_opposite_myon(Enemy *e, int t) {
@@ -200,7 +200,7 @@ int youmu_split(Enemy *e, int t) {
 	
 	FROM_TO(100,170,10) {
 		tsrand_fill(3);
-		create_particle1c("youmu_slice", VIEWPORT_W/2.0 + VIEWPORT_H/2.0*I - 200-200I + 400*afrand(0)+400I*afrand(1), NULL, Slice, timeout, 100-_i)->angle = 360.0*afrand(2);
+		create_particle1c("youmu_slice", VIEWPORT_W/2.0 + VIEWPORT_H/2.0*I - 200-200.0I + 400*afrand(0)+400.0I*afrand(1), NULL, Slice, timeout, 100-_i)->angle = 360.0*afrand(2);
 	}
 	
 	
@@ -223,8 +223,8 @@ void youmu_shot(Player *plr) {
 			play_sound("generic_shot");
 		
 		if(!(global.frames % 6)) {
-			create_projectile1c("youmu", plr->pos + 10 - I*20, NULL, linear, -20I)->type = PlrProj+120;
-			create_projectile1c("youmu", plr->pos - 10 - I*20, NULL, linear, -20I)->type = PlrProj+120;		
+			create_projectile1c("youmu", plr->pos + 10 - I*20, NULL, linear, -20.0I)->type = PlrProj+120;
+			create_projectile1c("youmu", plr->pos - 10 - I*20, NULL, linear, -20.0I)->type = PlrProj+120;		
 		}
 		
 		if(plr->shot == YoumuHoming) {
@@ -237,36 +237,36 @@ void youmu_shot(Player *plr) {
 				if(ref == -1)
 					ref = add_ref(NULL);
 				
-				create_projectile2c("youhoming", plr->pos, NULL, youmu_homing, -3I, ref)->type = PlrProj+(450+225*((int)plr->power));
+				create_projectile2c("youhoming", plr->pos, NULL, youmu_homing, -3.0I, ref)->type = PlrProj+(450+225*((int)plr->power));
 			}
 			
 			if(!plr->focus && !(global.frames % (int)round(8-plr->power*1.3))) {												
-				create_projectile2c("hghost", plr->pos, NULL, accelerated, 2-10I, -0.4I)->type = PlrProj+27;
-				create_projectile2c("hghost", plr->pos, NULL, accelerated, -10I, -0.4I)->type = PlrProj+27;
-				create_projectile2c("hghost", plr->pos, NULL, accelerated, -2-10I, -0.4I)->type = PlrProj+27;
+				create_projectile2c("hghost", plr->pos, NULL, accelerated, 2-10.0I, -0.4I)->type = PlrProj+27;
+				create_projectile2c("hghost", plr->pos, NULL, accelerated, -10.0I, -0.4I)->type = PlrProj+27;
+				create_projectile2c("hghost", plr->pos, NULL, accelerated, -2-10.0I, -0.4I)->type = PlrProj+27;
 			}
 		}
 	}
 	
 	if(plr->shot == YoumuOpposite && plr->slaves == NULL)
-		create_enemy_p(&plr->slaves, 40I, ENEMY_IMMUNE, YoumuOppositeMyon, youmu_opposite_myon, 0, 0, 0, 0);
+		create_enemy_p(&plr->slaves, 40.0I, ENEMY_IMMUNE, YoumuOppositeMyon, youmu_opposite_myon, 0, 0, 0, 0);
 }
 
 void youmu_bomb(Player *plr) {
 	switch(plr->shot) {
 		case YoumuOpposite:			
-			create_enemy_p(&plr->slaves, 40I, ENEMY_BOMB, NULL, youmu_split, 280,0,0,0);
+			create_enemy_p(&plr->slaves, 40.0I, ENEMY_BOMB, NULL, youmu_split, 280,0,0,0);
 			
 			break;
 		case YoumuHoming:
-			create_enemy_p(&plr->slaves, 40I, ENEMY_BOMB, YoumuSlash, youmu_slash, 280,0,0,0);
+			create_enemy_p(&plr->slaves, 40.0I, ENEMY_BOMB, YoumuSlash, youmu_slash, 280,0,0,0);
 			break;
 	}
 }
 
 void youmu_power(Player *plr, float npow) {
 	if(plr->shot == YoumuOpposite && plr->slaves == NULL)
-		create_enemy_p(&plr->slaves, 40I, ENEMY_IMMUNE, YoumuOppositeMyon, youmu_opposite_myon, 0, 0, 0, 0);
+		create_enemy_p(&plr->slaves, 40.0I, ENEMY_IMMUNE, YoumuOppositeMyon, youmu_opposite_myon, 0, 0, 0, 0);
 }
 
 /* Marisa */
@@ -377,7 +377,7 @@ void MasterSpark(Enemy *e, int t) {
 // 	glColor4f(0.9,1,1,fade*0.8);
 	int i;
 	for(i = 0; i < 8; i++)
-		draw_masterspark_ring(global.plr.pos - 50I, t%20 + 10*i, fade);
+		draw_masterspark_ring(global.plr.pos - 50.0I, t%20 + 10*i, fade);
 	
 	glColor4f(1,1,1,1);
 }
@@ -472,8 +472,8 @@ void marisa_shot(Player *plr) {
 			play_sound("generic_shot");
 		
 		if(!(global.frames % 6)) {
-			create_projectile1c("marisa", plr->pos + 10 - 15I, NULL, linear, -20I)->type = PlrProj+150;
-			create_projectile1c("marisa", plr->pos - 10 - 15I, NULL, linear, -20I)->type = PlrProj+150;
+			create_projectile1c("marisa", plr->pos + 10 - 15.0I, NULL, linear, -20.0I)->type = PlrProj+150;
+			create_projectile1c("marisa", plr->pos - 10 - 15.0I, NULL, linear, -20.0I)->type = PlrProj+150;
 		}
 	}
 }
@@ -484,7 +484,7 @@ void marisa_bomb(Player *plr) {
 	switch(plr->shot) {
 	case MarisaLaser:
 		play_sound("masterspark");
-		create_enemy_p(&plr->slaves, 40I, ENEMY_BOMB, MasterSpark, master_spark, 280,0,0,0);
+		create_enemy_p(&plr->slaves, 40.0I, ENEMY_BOMB, MasterSpark, master_spark, 280,0,0,0);
 		break;
 	case MarisaStar:
 		for(i = 0; i < 20; i++) {
@@ -514,36 +514,36 @@ void marisa_power(Player *plr, float npow) {
 	switch(plr->shot) {
 	case MarisaLaser:
 		if((int)npow == 1)
-			create_enemy_p(&plr->slaves, -40I, ENEMY_IMMUNE, MariLaserSlave, marisa_laser_slave, -40I, 5, 0, 0);
+			create_enemy_p(&plr->slaves, -40.0I, ENEMY_IMMUNE, MariLaserSlave, marisa_laser_slave, -40.0I, 5, 0, 0);
 		
 		if(npow >= 2) {
-			create_enemy_p(&plr->slaves, 25-5I, ENEMY_IMMUNE, MariLaserSlave, marisa_laser_slave, 8-40I, 5,    M_PI/30, 0);
-			create_enemy_p(&plr->slaves, -25-5I, ENEMY_IMMUNE, MariLaserSlave, marisa_laser_slave, -8-40I, 5, -M_PI/30, 0);
+			create_enemy_p(&plr->slaves, 25-5.0I, ENEMY_IMMUNE, MariLaserSlave, marisa_laser_slave, 8-40.0I, 5,    M_PI/30, 0);
+			create_enemy_p(&plr->slaves, -25-5.0I, ENEMY_IMMUNE, MariLaserSlave, marisa_laser_slave, -8-40.0I, 5, -M_PI/30, 0);
 		}
 		
 		if((int)npow == 3)
-			create_enemy_p(&plr->slaves, -30I, ENEMY_IMMUNE, MariLaserSlave, marisa_laser_slave, -50I, 5, 0, 0);
+			create_enemy_p(&plr->slaves, -30.0I, ENEMY_IMMUNE, MariLaserSlave, marisa_laser_slave, -50.0I, 5, 0, 0);
 		
 		if(npow >= 4) {
-			create_enemy_p(&plr->slaves, 17-30I, ENEMY_IMMUNE, MariLaserSlave, marisa_laser_slave, 4-45I, 5, 0, 0);
-			create_enemy_p(&plr->slaves, -17-30I, ENEMY_IMMUNE, MariLaserSlave, marisa_laser_slave, -4-45I, 5, 0, 0);
+			create_enemy_p(&plr->slaves, 17-30.0I, ENEMY_IMMUNE, MariLaserSlave, marisa_laser_slave, 4-45.0I, 5, 0, 0);
+			create_enemy_p(&plr->slaves, -17-30.0I, ENEMY_IMMUNE, MariLaserSlave, marisa_laser_slave, -4-45.0I, 5, 0, 0);
 		}
 		break;
 	case MarisaStar:
 		if((int)npow == 1)
-			create_enemy_p(&plr->slaves, 40I, ENEMY_IMMUNE, MariLaserSlave, marisa_star_slave, +30I, -2I, -0.1I, 5);
+			create_enemy_p(&plr->slaves, 40.0I, ENEMY_IMMUNE, MariLaserSlave, marisa_star_slave, +30.0I, -2.0I, -0.1I, 5);
 		
 		if(npow >= 2) {
 			double side = npow == 4? 0 : 0.3;
-			create_enemy_p(&plr->slaves, 30I+15, ENEMY_IMMUNE, MariLaserSlave, marisa_star_slave, +30I+10, -side-2I, -0.1I, 5);
-			create_enemy_p(&plr->slaves, 30I-15, ENEMY_IMMUNE, MariLaserSlave, marisa_star_slave, +30I-10, side-2I, -0.1I, 5);
+			create_enemy_p(&plr->slaves, 30.0I+15, ENEMY_IMMUNE, MariLaserSlave, marisa_star_slave, +30.0I+10, -side-2.0I, -0.1I, 5);
+			create_enemy_p(&plr->slaves, 30.0I-15, ENEMY_IMMUNE, MariLaserSlave, marisa_star_slave, +30.0I-10, side-2.0I, -0.1I, 5);
 		}
 		
 		if((int)npow == 3)
-			create_enemy_p(&plr->slaves, -30I, ENEMY_IMMUNE, MariLaserSlave, marisa_star_slave, +30I, -2I, -0.1I, 5);
+			create_enemy_p(&plr->slaves, -30.0I, ENEMY_IMMUNE, MariLaserSlave, marisa_star_slave, +30.0I, -2.0I, -0.1I, 5);
 		if(npow >= 4) {
-			create_enemy_p(&plr->slaves, 30, ENEMY_IMMUNE, MariLaserSlave, marisa_star_slave, 25+30I, -0.5-2I, -0.1I, 5);
-			create_enemy_p(&plr->slaves, -30, ENEMY_IMMUNE, MariLaserSlave, marisa_star_slave, -25+30I, 0.5-2I, -0.1I, 5);
+			create_enemy_p(&plr->slaves, 30, ENEMY_IMMUNE, MariLaserSlave, marisa_star_slave, 25+30.0I, -0.5-2.0I, -0.1I, 5);
+			create_enemy_p(&plr->slaves, -30, ENEMY_IMMUNE, MariLaserSlave, marisa_star_slave, -25+30.0I, 0.5-2.0I, -0.1I, 5);
 		}
 		break;
 	}

--- a/src/projectile.c
+++ b/src/projectile.c
@@ -419,6 +419,6 @@ void petal_explosion(int n, complex pos) {
 	int i;
 	for(i = 0; i < n; i++) {
 		tsrand_fill(8);
-		create_particle4c("petal", pos, rgba(0.6,1-afrand(0)*0.4,0.5,1-0.5*afrand(1)), Petal, asymptotic, (3+5*afrand(2))*cexp(I*M_PI*2*afrand(3)), 5, afrand(4) + afrand(5)*I, afrand(6) + 360I*afrand(7));
+		create_particle4c("petal", pos, rgba(0.6,1-afrand(0)*0.4,0.5,1-0.5*afrand(1)), Petal, asymptotic, (3+5*afrand(2))*cexp(I*M_PI*2*afrand(3)), 5, afrand(4) + afrand(5)*I, afrand(6) + 360.0I*afrand(7));
 	}
 }

--- a/src/stage.c
+++ b/src/stage.c
@@ -253,8 +253,8 @@ void stage_draw(StageInfo *info, StageRule bgdraw, ShaderRule *shaderrules, int 
 		glTranslatef(creal(global.boss->pos), cimag(global.boss->pos), 0);
 		
 		if(!(global.frames % 5)) {
-			complex offset = (frand()-0.5)*50 + (frand()-0.5)*20I;
-			create_particle3c("boss_shadow", -20I, rgba(0.2,0.35,0.5,0.5), EnemyFlareShrink, enemy_flare, 50, (-100I-offset)/(50.0+frand()*10), add_ref(global.boss));
+			complex offset = (frand()-0.5)*50 + (frand()-0.5)*20.0I;
+			create_particle3c("boss_shadow", -20.0I, rgba(0.2,0.35,0.5,0.5), EnemyFlareShrink, enemy_flare, 50, (-100.0I-offset)/(50.0+frand()*10), add_ref(global.boss));
 		}
 		
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE);

--- a/src/stages/stage1.c
+++ b/src/stages/stage1.c
@@ -110,7 +110,7 @@ void stage1_draw(void) {
 
 void cirno_intro(Boss *c, int time) {
 
-	GO_TO(c, VIEWPORT_W/2.0 + 100I, 0.035);
+	GO_TO(c, VIEWPORT_W/2.0 + 100.0I, 0.035);
 }
 
 void cirno_icy(Boss *c, int time) {
@@ -167,7 +167,7 @@ void cirno_perfect_freeze(Boss *c, int time) {
 		return;
 	
 	FROM_TO(-40, 0, 1)
-		GO_TO(c, VIEWPORT_W/2.0 + 100I, 0.04);
+		GO_TO(c, VIEWPORT_W/2.0 + 100.0I, 0.04);
 		
 	FROM_TO(20,80,1) {
 		float r = frand();
@@ -180,7 +180,7 @@ void cirno_perfect_freeze(Boss *c, int time) {
 			create_projectile2c("ball", c->pos, rgb(r, g, b), cirno_pfreeze_frogs, 4*cexp(I*tsrand()), add_ref(global.boss));		
 	}
 	
-	GO_AT(c, 160, 190, 2 + 1I);
+	GO_AT(c, 160, 190, 2 + 1.0I);
 
 	FROM_TO(160, 220, 6-global.diff) {
 		create_projectile2c("rice", c->pos + 60, rgb(0.3, 0.4, 0.9), asymptotic, (2.5+0.5*global.diff)*cexp(I*(carg(global.plr.pos - c->pos) + 0.5*nfrand())), 2.5);
@@ -190,7 +190,7 @@ void cirno_perfect_freeze(Boss *c, int time) {
 	GO_AT(c, 190, 220, -2);
 	
 	FROM_TO(280, 320, 1)
-		GO_TO(c, VIEWPORT_W/2.0 + 100I, 0.04);
+		GO_TO(c, VIEWPORT_W/2.0 + 100.0I, 0.04);
 }
 
 void cirno_pfreeze_bg(Boss *c, int time) {
@@ -206,7 +206,7 @@ void cirno_pfreeze_bg(Boss *c, int time) {
 }
 	
 Boss *create_cirno_mid(void) {
-	Boss* cirno = create_boss("Cirno", "cirno", VIEWPORT_W + 220 + 30I);
+	Boss* cirno = create_boss("Cirno", "cirno", VIEWPORT_W + 220 + 30.0I);
 	boss_add_attack(cirno, AT_Move, "Introduction", 2, 0, cirno_intro, NULL);
 	boss_add_attack(cirno, AT_Normal, "Icy Storm", 20, 20000, cirno_icy, NULL);
 	boss_add_attack(cirno, AT_Spellcard, "Freeze Sign ~ Perfect Freeze", 32, 20000, cirno_perfect_freeze, cirno_pfreeze_bg);
@@ -219,7 +219,7 @@ void cirno_intro_boss(Boss *c, int time) {
 	if(time < 0)
 		return;
 	TIMER(&time);
-	GO_TO(c, VIEWPORT_W/2.0 + 100I, 0.035);
+	GO_TO(c, VIEWPORT_W/2.0 + 100.0I, 0.035);
 		
 	AT(100)
 		global.dialog = stage1_dialog();
@@ -241,7 +241,7 @@ void cirno_iceplosion0(Boss *c, int time) {
 	}
 	
 	FROM_TO(40,100,1) {
-		create_projectile2c("crystal", c->pos, rgb(0.3,0.3,0.8), accelerated, 2*cexp(2I*M_PI*frand()) + 2I, 0.002*cexp(I*(M_PI/10.0*(_i%20))));
+		create_projectile2c("crystal", c->pos, rgb(0.3,0.3,0.8), accelerated, 2*cexp(2.0I*M_PI*frand()) + 2.0I, 0.002*cexp(I*(M_PI/10.0*(_i%20))));
 	}
 	
 	FROM_TO(150, 300, 30-5*global.diff) {
@@ -262,7 +262,7 @@ void cirno_crystal_rain(Boss *c, int time) {
 	
 	if(frand() > 0.9-0.1*global.diff) {
 		tsrand_fill(2);
-		create_projectile2c("crystal", VIEWPORT_W*afrand(0), rgb(0.2,0.2,0.4), accelerated, 1I, 0.01I + (0.01+0.003*global.diff)*anfrand(1));
+		create_projectile2c("crystal", VIEWPORT_W*afrand(0), rgb(0.2,0.2,0.4), accelerated, 1.0I, 0.01I + (0.01+0.003*global.diff)*anfrand(1));
 	}
 	
 	FROM_TO(100, 400, 120-20*global.diff) {
@@ -277,7 +277,7 @@ void cirno_crystal_rain(Boss *c, int time) {
 	GO_AT(c, 230, 300, -1+0.6I);
 	
 	FROM_TO(400, 500, 1)
-		GO_TO(c, VIEWPORT_W/2.0 + 100I, 0.01);
+		GO_TO(c, VIEWPORT_W/2.0 + 100.0I, 0.01);
 }
 
 void cirno_iceplosion1(Boss *c, int time) {
@@ -285,7 +285,7 @@ void cirno_iceplosion1(Boss *c, int time) {
 	TIMER(&t);
 	
 	if(time < 0)
-		GO_TO(c, VIEWPORT_W/2.0 + 100I, 0.02);
+		GO_TO(c, VIEWPORT_W/2.0 + 100.0I, 0.02);
 	
 	FROM_TO(20,30,2) {
 		int i;
@@ -295,8 +295,8 @@ void cirno_iceplosion1(Boss *c, int time) {
 	}
 	
 	FROM_TO(40,100,2) {
-		create_projectile2c("crystal", c->pos + 100, rgb(0.3,0.3,0.8), accelerated, 1.5*cexp(2I*M_PI*frand()) - 0.4 + 2I, 0.002*cexp(I*(M_PI/10.0*(_i%20))));
-		create_projectile2c("crystal", c->pos - 100, rgb(0.3,0.3,0.8), accelerated, 1.5*cexp(2I*M_PI*frand()) + 0.4 + 2I, 0.002*cexp(I*(M_PI/10.0*(_i%20))));
+		create_projectile2c("crystal", c->pos + 100, rgb(0.3,0.3,0.8), accelerated, 1.5*cexp(2.0I*M_PI*frand()) - 0.4 + 2.0I, 0.002*cexp(I*(M_PI/10.0*(_i%20))));
+		create_projectile2c("crystal", c->pos - 100, rgb(0.3,0.3,0.8), accelerated, 1.5*cexp(2.0I*M_PI*frand()) + 0.4 + 2.0I, 0.002*cexp(I*(M_PI/10.0*(_i%20))));
 	}
 	
 	FROM_TO(150, 300, 30) {
@@ -334,7 +334,7 @@ void cirno_icicle_fall(Boss *c, int time) {
 	if(time < 0)
 		return;
 	
-	GO_TO(c, VIEWPORT_W/2.0+120I, 0.01);
+	GO_TO(c, VIEWPORT_W/2.0+120.0I, 0.01);
 		
 	FROM_TO(20,200,30) {
 		int i;
@@ -346,7 +346,7 @@ void cirno_icicle_fall(Boss *c, int time) {
 }
 
 Boss *create_cirno(void) {
-	Boss* cirno = create_boss("Cirno", "cirno", -230 + 100I);
+	Boss* cirno = create_boss("Cirno", "cirno", -230 + 100.0I);
 	boss_add_attack(cirno, AT_Move, "Introduction", 2, 0, cirno_intro_boss, NULL);
 	boss_add_attack(cirno, AT_Normal, "Iceplosion 0", 20, 20000, cirno_iceplosion0, NULL);
 	boss_add_attack(cirno, AT_Spellcard, "Freeze Sign ~ Crystal Rain", 28, 28000, cirno_crystal_rain, cirno_pfreeze_bg);
@@ -365,7 +365,7 @@ int stage1_burst(Enemy *e, int time) {
 	}	
 	
 	FROM_TO(0, 60, 1)
-		e->pos += 2I;
+		e->pos += 2.0I;
 	
 	AT(60) {
 		int i = 0;
@@ -478,7 +478,7 @@ int stage1_multiburst(Enemy *e, int t) {
 	}
 	
 	FROM_TO(0, 50, 1)
-		e->pos += 2I;
+		e->pos += 2.0I;
 	
 	FROM_TO_INT(60, 300, 70, 40, 12-global.diff) {
 		int i;
@@ -541,7 +541,7 @@ int stage1_tritoss(Enemy *e, int t) {
 		int n = 3+global.diff/2;
 		
 		for(i = 0; i < n; i++)
-			create_projectile2c("thickrice", e->pos, rgb(0.2, 0.4, 0.8), asymptotic, 2*cexp(I*a+2I*M_PI/n*i), 3);		
+			create_projectile2c("thickrice", e->pos, rgb(0.2, 0.4, 0.8), asymptotic, 2*cexp(I*a+2.0I*M_PI/n*i), 3);		
 	}
 	
 	FROM_TO(480, 800, 300) {
@@ -598,15 +598,15 @@ void stage1_events(void) {
 	// swirl, sine pass
 	FROM_TO(380, 1000, 20) {
 		tsrand_fill(2);
-		create_enemy2c(VIEWPORT_W*(_i&1) + afrand(0)*100I + 70I, 100, Swirl, stage1_sinepass, 3.5*(1-2*(_i&1)), afrand(1)*7I);
+		create_enemy2c(VIEWPORT_W*(_i&1) + afrand(0)*100.0I + 70.0I, 100, Swirl, stage1_sinepass, 3.5*(1-2*(_i&1)), afrand(1)*7.0I);
 	}
 	
 	// swirl, drops
 	FROM_TO(1100, 1600, 20)
-		create_enemy2c(VIEWPORT_W/3, 100, Swirl, stage1_drop, 4I, 0.06);
+		create_enemy2c(VIEWPORT_W/3, 100, Swirl, stage1_drop, 4.0I, 0.06);
 		
 	FROM_TO(1500, 2000, 20)
-		create_enemy2c(VIEWPORT_W+200I, 100, Swirl, stage1_drop, -2, -0.04-0.03I);
+		create_enemy2c(VIEWPORT_W+200.0I, 100, Swirl, stage1_drop, -2, -0.04-0.03I);
 	
 	// bursts
 	FROM_TO(1250, 1800, 60) {
@@ -617,7 +617,7 @@ void stage1_events(void) {
 	// circle - multi burst combo
 	FROM_TO(1700, 2300, 300) {
 		tsrand_fill(3);
-		create_enemy2c(VIEWPORT_W/2, 1400, BigFairy, stage1_circle, VIEWPORT_W/4 + VIEWPORT_W/2*afrand(0)+200I, 3-6*(afrand(1)>0.5)+afrand(2)*2I);
+		create_enemy2c(VIEWPORT_W/2, 1400, BigFairy, stage1_circle, VIEWPORT_W/4 + VIEWPORT_W/2*afrand(0)+200.0I, 3-6*(afrand(1)>0.5)+afrand(2)*2.0I);
 	}
 	
 	FROM_TO(2000, 2500, 200) {
@@ -632,12 +632,12 @@ void stage1_events(void) {
 	// some chaotic swirls + instant circle combo
 	FROM_TO(2760, 3800, 20) {
 		tsrand_fill(2);
-		create_enemy2c(VIEWPORT_W/2 - 200*anfrand(0), 250+40*global.diff, Swirl, stage1_drop, 1I, 0.001I + 0.02 + 0.06*anfrand(1));
+		create_enemy2c(VIEWPORT_W/2 - 200*anfrand(0), 250+40*global.diff, Swirl, stage1_drop, 1.0I, 0.001I + 0.02 + 0.06*anfrand(1));
 	}
 	
 	FROM_TO(2900, 3750, 190-30*global.diff) {
 		tsrand_fill(2);
-		create_enemy2c(VIEWPORT_W*afrand(0), 1200, Fairy, stage1_instantcircle, 2I, 3.0 - 6*afrand(1) - 1I);
+		create_enemy2c(VIEWPORT_W*afrand(0), 1200, Fairy, stage1_instantcircle, 2.0I, 3.0 - 6*afrand(1) - 1.0I);
 	}
 	
 		
@@ -651,7 +651,7 @@ void stage1_events(void) {
 		create_enemy2c(VIEWPORT_W*_i + VIEWPORT_H/3*I, 1700, Fairy, stage1_circletoss, 2-4*_i-0.3I, 1-2*_i);	
 		
 	AT(4200)
-		create_enemy2c(VIEWPORT_W/2.0, 4000, BigFairy, stage1_tritoss, 2I, -2.6I);
+		create_enemy2c(VIEWPORT_W/2.0, 4000, BigFairy, stage1_tritoss, 2.0I, -2.6I);
 		
 	AT(5000)
 		global.boss = create_cirno();

--- a/src/stages/stage2_events.c
+++ b/src/stages/stage2_events.c
@@ -66,7 +66,7 @@ int stage2_great_circle(Enemy *e, int t) {
 	}
 	
 	AT(210+global.diff*25) {
-		e->args[0] = 2I;
+		e->args[0] = 2.0I;
 	}
 	
 	return 1;
@@ -104,7 +104,7 @@ int stage2_small_spin_circle(Enemy *e, int t) {
 		e->pos0 = e->pos;
 		
 	FROM_TO(50,80+global.diff*5,5)
-		create_projectile3c("ball", e->pos, rgb(0.9,0.0,0.3), spin_circle, 0.02 - 0.04*(!e->dir), e->pos0 + _i*10*((1-2*e->dir)+1I), (1-2*e->dir)+1I);
+		create_projectile3c("ball", e->pos, rgb(0.9,0.0,0.3), spin_circle, 0.02 - 0.04*(!e->dir), e->pos0 + _i*10*((1-2*e->dir)+1.0I), (1-2*e->dir)+1.0I);
 	
 	return 1;
 }
@@ -172,7 +172,7 @@ int stage2_flea(Enemy *e, int t) {
 	
 		
 	FROM_TO(10, 400, 20-global.diff*2-t/70) {
-		create_projectile2c("flea", e->pos, rgb(0.2,0.2,1), asymptotic, 1.5*cexp(2I*M_PI*frand()), 1.5);
+		create_projectile2c("flea", e->pos, rgb(0.2,0.2,1), asymptotic, 1.5*cexp(2.0I*M_PI*frand()), 1.5);
 	}
 	
 	return 1;
@@ -192,7 +192,7 @@ int stage2_accel_circle(Enemy *e, int t) {
 		
 		int i;
 		for(i = 0; i < 6; i++) {
-			create_projectile2c("ball", e->pos, rgb(0.6,0.1,0.2), accelerated, 1.5*cexp(2I*M_PI/6*i)+cexp(I*carg(global.plr.pos - e->pos)), -0.02*cexp(I*(2*M_PI/6*i+0.02*frand()*global.diff)));
+			create_projectile2c("ball", e->pos, rgb(0.6,0.1,0.2), accelerated, 1.5*cexp(2.0I*M_PI/6*i)+cexp(I*carg(global.plr.pos - e->pos)), -0.02*cexp(I*(2*M_PI/6*i+0.02*frand()*global.diff)));
 		}
 	}
 	
@@ -204,7 +204,7 @@ int stage2_accel_circle(Enemy *e, int t) {
 
 void wriggle_intro(Boss *w, int t) {
 	if(t != EVENT_DEATH)
-		w->pos = VIEWPORT_W/2 + 100I + 400*(1.0-t/(4.0*FPS))*cexp(I*(3-t*0.04));
+		w->pos = VIEWPORT_W/2 + 100.0I + 400*(1.0-t/(4.0*FPS))*cexp(I*(3-t*0.04));
 }
 
 int wriggle_bug(Projectile *p, int t) {
@@ -244,7 +244,7 @@ void wriggle_small_storm(Boss *w, int time) {
 }
 
 Boss *create_wriggle_mid(void) {
-	Boss* wriggle = create_boss("Wriggle", "wriggle", VIEWPORT_W + 150 - 30I);
+	Boss* wriggle = create_boss("Wriggle", "wriggle", VIEWPORT_W + 150 - 30.0I);
 	boss_add_attack(wriggle, AT_Move, "Introduction", 4, 0, wriggle_intro, NULL);
 	boss_add_attack(wriggle, AT_Normal, "Small Bug Storm", 20, 20000, wriggle_small_storm, NULL);
 	
@@ -258,7 +258,7 @@ void hina_intro(Boss *h, int time) {
 	AT(100)
 		global.dialog = stage2_dialog();
 	
-	GO_TO(h, VIEWPORT_W/2 + 100I, 0.05);
+	GO_TO(h, VIEWPORT_W/2 + 100.0I, 0.05);
 }
 
 void hina_cards1(Boss *h, int time) {
@@ -281,7 +281,7 @@ void hina_amulet(Boss *h, int time) {
 		return;
 	
 	if(time < 100)
-		GO_TO(h, VIEWPORT_W/2 + 200I, 0.02);
+		GO_TO(h, VIEWPORT_W/2 + 200.0I, 0.02);
 	
 	TIMER(&t);
 	
@@ -324,12 +324,12 @@ void hina_bad_pick(Boss *h, int time) {
 	if(time < 0)
 		return;
 	
-	GO_TO(h, VIEWPORT_W/5*(time/400+0.6)+ 100I, 0.02);
+	GO_TO(h, VIEWPORT_W/5*(time/400+0.6)+ 100.0I, 0.02);
 	
 	FROM_TO(100, 500, 5) {
 		
 		for(i = 1; i < 5; i++) {
-			create_projectile1c("crystal", VIEWPORT_W/5*i, rgb(0.2,0,0.2), linear, 7I);
+			create_projectile1c("crystal", VIEWPORT_W/5*i, rgb(0.2,0,0.2), linear, 7.0I);
 		}
 	}
 	
@@ -392,7 +392,7 @@ void hina_spell_bg(Boss *h, int time) {
 }
 
 Boss *create_hina(void) {
-	Boss* hina = create_boss("Kagiyama Hina", "hina", VIEWPORT_W + 150 + 100I);
+	Boss* hina = create_boss("Kagiyama Hina", "hina", VIEWPORT_W + 150 + 100.0I);
 	boss_add_attack(hina, AT_Move, "Introduction", 2, 0, hina_intro, NULL);
 	boss_add_attack(hina, AT_Normal, "Cards1", 20, 15000, hina_cards1, NULL);
 	boss_add_attack(hina, AT_Spellcard, "Shard ~ Amulet of Harm", 26, 25000, hina_amulet, hina_spell_bg);
@@ -408,30 +408,30 @@ void stage2_events(void) {
 	TIMER(&global.timer);
 		
 	AT(300) {
-		create_enemy1c(VIEWPORT_W/2-10I, 7000+500*global.diff, BigFairy, stage2_great_circle, 2I);
+		create_enemy1c(VIEWPORT_W/2-10.0I, 7000+500*global.diff, BigFairy, stage2_great_circle, 2.0I);
 	}
 	
 	FROM_TO(650-50*global.diff, 750+25*(4-global.diff), 50) {
-		create_enemy1c(VIEWPORT_W*((_i)%2)+50I, 2000, Fairy, stage2_small_spin_circle, 2-4*(_i%2)+1I);
+		create_enemy1c(VIEWPORT_W*((_i)%2)+50.0I, 2000, Fairy, stage2_small_spin_circle, 2-4*(_i%2)+1.0I);
 	}
 	
 	FROM_TO(850, 1000, 15)
-		create_enemy1c(VIEWPORT_W/2+25*(_i-5)-20I, 200, Fairy, stage2_aim, (2+frand()*0.3)*I);
+		create_enemy1c(VIEWPORT_W/2+25*(_i-5)-20.0I, 200, Fairy, stage2_aim, (2+frand()*0.3)*I);
 		
 	FROM_TO(960, 1200, 20)
 		create_enemy3c(VIEWPORT_W-80+(VIEWPORT_H+20)*I, 200, Fairy, stage2_sidebox_trail, 3 - 0.5*M_PI*I, -0.02, 90);
 	
 	FROM_TO(1140, 1400, 20)
-		create_enemy3c(200-20I, 200, Fairy, stage2_sidebox_trail, 3+0.5I*M_PI, -0.05, 70);
+		create_enemy3c(200-20.0I, 200, Fairy, stage2_sidebox_trail, 3+0.5I*M_PI, -0.05, 70);
 		
 	AT(1300)
-		create_enemy1c(150-10I, 4000, BigFairy, stage2_great_circle, 2.5I);
+		create_enemy1c(150-10.0I, 4000, BigFairy, stage2_great_circle, 2.5I);
 		
 	AT(1500)
-		create_enemy1c(VIEWPORT_W-150-10I, 4000, BigFairy, stage2_great_circle, 2.5I);
+		create_enemy1c(VIEWPORT_W-150-10.0I, 4000, BigFairy, stage2_great_circle, 2.5I);
 		
 	FROM_TO(1700, 2000, 30)
-		create_enemy1c(VIEWPORT_W*frand()-20I, 200, Fairy, stage2_flea, 1.7I);
+		create_enemy1c(VIEWPORT_W*frand()-20.0I, 200, Fairy, stage2_flea, 1.7I);
 		
 	FROM_TO(1950, 2500, 60) {
 		create_enemy3c(VIEWPORT_W-40+(VIEWPORT_H+20)*I, 200, Fairy, stage2_sidebox_trail, 5 - 0.5*M_PI*I, -0.02, 83-global.diff*3);
@@ -439,8 +439,8 @@ void stage2_events(void) {
 	}
 	
 	AT(2500) {
-		create_enemy1c(VIEWPORT_W/4-10I, 2000, Fairy, stage2_accel_circle, 2I);
-		create_enemy1c(VIEWPORT_W/4*3-10I, 2000, Fairy, stage2_accel_circle, 2I);
+		create_enemy1c(VIEWPORT_W/4-10.0I, 2000, Fairy, stage2_accel_circle, 2.0I);
+		create_enemy1c(VIEWPORT_W/4*3-10.0I, 2000, Fairy, stage2_accel_circle, 2.0I);
 	}
 		
 	AT(2800)
@@ -452,14 +452,14 @@ void stage2_events(void) {
 	}
 	
 	FROM_TO(3000, 3600, 300) {
-		create_enemy1c(VIEWPORT_W/2-60*(_i-1)-10I, 7000+500*global.diff, BigFairy, stage2_great_circle, 2I);
+		create_enemy1c(VIEWPORT_W/2-60*(_i-1)-10.0I, 7000+500*global.diff, BigFairy, stage2_great_circle, 2.0I);
 	}
 	
 	FROM_TO(3700, 4500, 40)
-		create_enemy1c(VIEWPORT_W*frand()-10I, 150, Fairy, stage2_flea, 2.5I);
+		create_enemy1c(VIEWPORT_W*frand()-10.0I, 150, Fairy, stage2_flea, 2.5I);
 		
 	FROM_TO(4000, 4600, 100)
-		create_enemy1c(VIEWPORT_W/2+100-200*frand()-10I, 2000, Fairy, stage2_accel_circle, 2I);
+		create_enemy1c(VIEWPORT_W/2+100-200*frand()-10.0I, 2000, Fairy, stage2_accel_circle, 2.0I);
 		
 	AT(5100) {
 		global.boss = create_hina();

--- a/src/stages/stage3_events.c
+++ b/src/stages/stage3_events.c
@@ -95,7 +95,7 @@ int stage3_slavefairy(Enemy *e, int t) {
 	}
 	
 	if(t >= 120)
-		e->pos += 3 * e->args[2] + 2I;
+		e->pos += 3 * e->args[2] + 2.0I;
 	
 	return 0;
 }
@@ -151,7 +151,7 @@ int stage3_bitchswirl(Enemy *e, int t) {
 		);
 	}
 	
-	e->pos -= 5I * e->args[0];
+	e->pos -= 5.0I * e->args[0];
 	
 	return 0;
 }
@@ -206,7 +206,7 @@ int stage3_cornerfairy(Enemy *e, int t) {
 }
 
 void stage3_mid_intro(Boss *boss, int time) {
-	GO_TO(boss, VIEWPORT_W/2.0 + 100I, 0.03);
+	GO_TO(boss, VIEWPORT_W/2.0 + 100.0I, 0.03);
 }
 
 void stage3_mid_outro(Boss *boss, int time) {
@@ -425,7 +425,7 @@ void stage3_boss_spellbg(Boss *b, int time) {
 }
 
 Boss* stage3_create_midboss(void) {
-	Boss *scuttle = create_boss("Scuttle", "scuttle", VIEWPORT_W/2 - 200I);
+	Boss *scuttle = create_boss("Scuttle", "scuttle", VIEWPORT_W/2 - 200.0I);
 	boss_add_attack(scuttle, AT_Move, "Introduction", 2, 0, stage3_mid_intro, NULL);
 	boss_add_attack(scuttle, AT_Normal, "Lethal Bite", 30, 25000, stage3_mid_a0, NULL);
 	boss_add_attack(scuttle, AT_Spellcard, "Venom Sign ~ Deadly Dance", 25, 25000, stage3_mid_a1, stage3_mid_spellbg);
@@ -751,11 +751,11 @@ void stage3_boss_intro(Boss *boss, int time) {
 	if(time == 110)
 		global.dialog = stage3_dialog();
 	
-	GO_TO(boss, VIEWPORT_W/2.0 + 100I, 0.03);
+	GO_TO(boss, VIEWPORT_W/2.0 + 100.0I, 0.03);
 }
 
 Boss* stage3_create_boss(void) {
-	Boss *wriggle = create_boss("Wriggle EX", "wriggleex", VIEWPORT_W/2 - 200I);
+	Boss *wriggle = create_boss("Wriggle EX", "wriggleex", VIEWPORT_W/2 - 200.0I);
 	boss_add_attack(wriggle, AT_Move, "Introduction", 2, 0, stage3_boss_intro, NULL);
 	
 	boss_add_attack(wriggle, AT_Normal, "", 20, 15000, stage3_boss_prea1, NULL);
@@ -797,8 +797,8 @@ void stage3_events(void) {
 	AT(2400) {
 		double offs = -50;
 		
-		complex p1 = 0+0I;
-		complex p2 = VIEWPORT_W+0I;
+		complex p1 = 0+0.0I;
+		complex p2 = VIEWPORT_W+0.0I;
 		complex p3 = VIEWPORT_W + VIEWPORT_H*I;
 		complex p4 = 0+VIEWPORT_H*I;
 		
@@ -836,8 +836,8 @@ void stage3_events(void) {
 	AT(4330) {
 		double offs = -50;
 		
-		complex p1 = 0+0I;
-		complex p2 = VIEWPORT_W+0I;
+		complex p1 = 0+0.0I;
+		complex p2 = VIEWPORT_W+0.0I;
 		complex p3 = VIEWPORT_W + VIEWPORT_H*I;
 		complex p4 = 0+VIEWPORT_H*I;
 		
@@ -848,8 +848,8 @@ void stage3_events(void) {
 	}
 	
 	FROM_TO(4760, 4940, 10) {
-		create_enemy2c(VIEWPORT_W-20 - 20I, 50, Swirl, stage3_bitchswirl, -0.5, 1);
-		create_enemy2c(20 + -20I, 50, Swirl, stage3_bitchswirl, -0.5, 1);
+		create_enemy2c(VIEWPORT_W-20 - 20.0I, 50, Swirl, stage3_bitchswirl, -0.5, 1);
+		create_enemy2c(20 + -20.0I, 50, Swirl, stage3_bitchswirl, -0.5, 1);
 	}
 	
 	AT(5300)

--- a/src/stages/stage4_events.c
+++ b/src/stages/stage4_events.c
@@ -192,7 +192,7 @@ int stage4_bigcircle(Enemy *e, int t) {
 		int i;
 		int n = 10+3*global.diff;
 		for(i = 0; i < n; i++)
-			create_projectile2c("bigball", e->pos, rgb(0,0.8-0.4*_i,0), asymptotic, 2*cexp(2I*M_PI/n*i+I*M_PI*_i), 3*sin(6*M_PI/n*i));
+			create_projectile2c("bigball", e->pos, rgb(0,0.8-0.4*_i,0), asymptotic, 2*cexp(2.0I*M_PI/n*i+I*M_PI*_i), 3*sin(6*M_PI/n*i));
 	}
 	return 1;
 }
@@ -222,13 +222,13 @@ int stage4_explosive(Enemy *e, int t) {
 void KurumiSlave(Enemy *e, int t) {
 	if(!(t%2)) {
 		complex offset  = (frand()-0.5)*30;
-				offset += (frand()-0.5)*20I;
-		create_particle3c("lasercurve", offset, rgb(0.3,0.0,0.0), EnemyFlareShrink, enemy_flare, 50, (-50I-offset)/50.0, add_ref(e));
+				offset += (frand()-0.5)*20.0I;
+		create_particle3c("lasercurve", offset, rgb(0.3,0.0,0.0), EnemyFlareShrink, enemy_flare, 50, (-50.0I-offset)/50.0, add_ref(e));
 	}		
 }
 
 void kurumi_intro(Boss *b, int t) {
-	GO_TO(b, VIEWPORT_W/2.0+200I, 0.01);
+	GO_TO(b, VIEWPORT_W/2.0+200.0I, 0.01);
 }
 
 int kurumi_burstslave(Enemy *e, int t) {
@@ -248,8 +248,8 @@ int kurumi_burstslave(Enemy *e, int t) {
 		
 	FROM_TO(0, 600, 18-2*global.diff) {
 		float r = cimag(e->pos)/VIEWPORT_H;
-		create_projectile2c("wave", e->pos + 10I*e->args[0], rgb(r,0,0), accelerated, 2I*e->args[0], -0.01*e->args[1]);
-		create_projectile2c("wave", e->pos - 10I*e->args[0], rgb(r,0,0), accelerated, -2I*e->args[0], -0.01*e->args[1]);
+		create_projectile2c("wave", e->pos + 10.0I*e->args[0], rgb(r,0,0), accelerated, 2.0I*e->args[0], -0.01*e->args[1]);
+		create_projectile2c("wave", e->pos - 10.0I*e->args[0], rgb(r,0,0), accelerated, -2.0I*e->args[0], -0.01*e->args[1]);
 	}
 	
 	FROM_TO(40, 100,1) {
@@ -298,8 +298,8 @@ int kurumi_spikeslave(Enemy *e, int t) {
 	
 	FROM_TO(0, 600, 18-2*global.diff) {
 		float r = cimag(e->pos)/VIEWPORT_H;
-		create_projectile2c("wave", e->pos + 10I*e->args[0], rgb(r,0,0), linear, 1.5I*e->args[1], -0.01*e->args[0]);
-		create_projectile2c("wave", e->pos - 10I*e->args[0], rgb(r,0,0), linear, -1.5I*e->args[1], -0.01*e->args[0]);
+		create_projectile2c("wave", e->pos + 10.0I*e->args[0], rgb(r,0,0), linear, 1.5I*e->args[1], -0.01*e->args[0]);
+		create_projectile2c("wave", e->pos - 10.0I*e->args[0], rgb(r,0,0), linear, -1.5I*e->args[1], -0.01*e->args[0]);
 	}
 	
 	return 1;
@@ -325,12 +325,12 @@ void kurumi_redspike(Boss *b, int time) {
 			int i;
 			int n = global.diff*8;
 			for(i = 0; i < n; i++)
-				create_projectile2c("bigball", b->pos, rgb(1,0,0), asymptotic, 3*cexp(2I*M_PI/n*i+I*carg(global.plr.pos-b->pos)), 3)->draw=ProjDrawAdd;
+				create_projectile2c("bigball", b->pos, rgb(1,0,0), asymptotic, 3*cexp(2.0I*M_PI/n*i+I*carg(global.plr.pos-b->pos)), 3)->draw=ProjDrawAdd;
 		}
 	} else {
 		FROM_TO(80, 500, 2+2*(global.diff == D_Hard)) {
 			tsrand_fill(2);
-			complex offset = 100*afrand(0)*cexp(2I*M_PI*afrand(1));
+			complex offset = 100*afrand(0)*cexp(2.0I*M_PI*afrand(1));
 			complex n = cexp(I*carg(global.plr.pos-b->pos-offset));
 			create_projectile2c("rice", b->pos+offset, rgb(1,0,0), accelerated, -1*n, 0.05*n)->draw=ProjDrawAdd;
 		}
@@ -360,7 +360,7 @@ void kurumi_outro(Boss *b, int time) {
 }
 
 Boss *create_kurumi_mid(void) {
-	Boss* b = create_boss("Kurumi", "kurumi", VIEWPORT_W/2-400I);
+	Boss* b = create_boss("Kurumi", "kurumi", VIEWPORT_W/2-400.0I);
 	boss_add_attack(b, AT_Move, "Introduction", 4, 0, kurumi_intro, NULL);
 	boss_add_attack(b, AT_Spellcard, "Bloodless ~ Gate of Walachia", 25, 20000, kurumi_slaveburst, kurumi_spell_bg);
 	boss_add_attack(b, AT_Spellcard, global.diff < D_Hard ? "Bloodless ~ Dry Fountain" : "Bloodless ~ Red Spike", 30, 30000, kurumi_redspike, kurumi_spell_bg);
@@ -412,7 +412,7 @@ int stage4_supercard(Enemy *e, int t) {
 
 void kurumi_boss_intro(Boss *b, int t) {
 	TIMER(&t);
-	GO_TO(b, VIEWPORT_W/2.0+200I, 0.01);
+	GO_TO(b, VIEWPORT_W/2.0+200.0I, 0.01);
 	
 	AT(400)
 		global.dialog = stage4_dialog();
@@ -431,10 +431,10 @@ void kurumi_breaker(Boss *b, int time) {
 	TIMER(&t);
 	
 	FROM_TO(50, 400, 50-7*global.diff) {
-		complex p = b->pos + 150*sin(_i) + 100I*cos(_i);
+		complex p = b->pos + 150*sin(_i) + 100.0I*cos(_i);
 		
 		for(i = 0; i < c; i++) {			
-			complex n = cexp(2I*M_PI/c*i);
+			complex n = cexp(2.0I*M_PI/c*i);
 			create_projectile4c("rice", p, rgb(1,0,0.5), splitcard, 3*n, 0,
 									kt, 1.5*cexp(I*carg(global.plr.pos - p - 2*kt*n))-2.6*n);
 			
@@ -443,7 +443,7 @@ void kurumi_breaker(Boss *b, int time) {
 	
 	FROM_TO(60, 400, 100) {
 		for(i = 0; i < 20; i++)
-			create_projectile2c("bigball", b->pos, rgb(0.5,0,0.5), asymptotic, cexp(2I*M_PI/20.0*i), 3);
+			create_projectile2c("bigball", b->pos, rgb(0.5,0,0.5), asymptotic, cexp(2.0I*M_PI/20.0*i), 3);
 	}
 	
 }
@@ -489,7 +489,7 @@ int aniwall_slave(Enemy *e, int t) {
 		if(re == 0 || re == VIEWPORT_W) {
 			
 			e->args[1] = 1;
-			e->args[2] = 10I;
+			e->args[2] = 10.0I;
 		}
 		
 		e->pos += e->args[0]*t;		
@@ -548,9 +548,9 @@ void kurumi_sbreaker(Boss *b, int time) {
 	int kt = 40;
 	
 	FROM_TO(50, 400, 2) {
-		complex p = b->pos + 150*sin(_i/8.0)+100I*cos(_i/15.0);
+		complex p = b->pos + 150*sin(_i/8.0)+100.0I*cos(_i/15.0);
 			
-		complex n = cexp(2I*M_PI/c*_i);
+		complex n = cexp(2.0I*M_PI/c*_i);
 		create_projectile4c("rice", p, rgb(1,0,0.5), splitcard, 2*n, 0,
 								kt, 1.5*cexp(I*carg(global.plr.pos - p - 2*kt*n))-1.7*n);
 
@@ -558,7 +558,7 @@ void kurumi_sbreaker(Boss *b, int time) {
 	
 	FROM_TO(60, 400, 100) {
 		for(i = 0; i < 20; i++)
-			create_projectile2c("bigball", b->pos, rgb(0.5,0,0.5), asymptotic, cexp(2I*M_PI/20.0*i), 3);
+			create_projectile2c("bigball", b->pos, rgb(0.5,0,0.5), asymptotic, cexp(2.0I*M_PI/20.0*i), 3);
 	}
 	
 }
@@ -600,7 +600,7 @@ int blowwall_slave(Enemy *e, int t) {
 			else
 				type = "plainball";
 			
-			create_projectile2c(type, e->pos, rgb(1, 0.1, 0.1), asymptotic, (1+3*f)*cexp(2I*M_PI*frand()), 4)->draw=ProjDrawAdd;
+			create_projectile2c(type, e->pos, rgb(1, 0.1, 0.1), asymptotic, (1+3*f)*cexp(2.0I*M_PI*frand()), 4)->draw=ProjDrawAdd;
 		}
 		
 		return ACTION_DESTROY;
@@ -647,7 +647,7 @@ int kdanmaku_slave(Enemy *e, int t) {
 	if(!e->args[1])
 		e->pos += e->args[0]*t;
 	else
-		e->pos += 5I;	
+		e->pos += 5.0I;	
 	
 	if(creal(e->pos) <= 0)
 		e->pos = I*cimag(e->pos);
@@ -669,7 +669,7 @@ int kdanmaku_slave(Enemy *e, int t) {
 			for(i = 0; i < n; i++) {
 				complex p = VIEWPORT_W/(float)n*(i+frand()) + I*cimag(e->pos);
 				if(cabs(p-global.plr.pos) > 60)
-					create_projectile1c("thickrice", p, rgb(1, 0.5, 0.5), linear, 0.5*cexp(2I*M_PI*frand()))->draw = ProjDrawAdd;
+					create_projectile1c("thickrice", p, rgb(1, 0.5, 0.5), linear, 0.5*cexp(2.0I*M_PI*frand()))->draw = ProjDrawAdd;
 			}
 		}
 	}
@@ -696,7 +696,7 @@ void kurumi_danmaku(Boss *b, int time) {
 
 
 Boss *create_kurumi(void) {
-	Boss* b = create_boss("Kurumi", "kurumi", -400I);
+	Boss* b = create_boss("Kurumi", "kurumi", -400.0I);
 	boss_add_attack(b, AT_Move, "Introduction", 4, 0, kurumi_boss_intro, NULL);
 	boss_add_attack(b, AT_Normal, "Sin Breaker", 20, 20000, kurumi_sbreaker, NULL);
 	boss_add_attack(b, AT_Spellcard, global.diff < D_Hard ? "Limit ~ Animate Wall" : "Summoning ~ Demon Wall", 30, 40000, kurumi_aniwall, kurumi_spell_bg);
@@ -715,12 +715,12 @@ void stage4_events(void) {
 	TIMER(&global.timer);
 	
 	AT(70) {
-		create_enemy1c(VIEWPORT_H/4*3*I, 3000, BigFairy, stage4_splasher, 3-4I);
-		create_enemy1c(VIEWPORT_W + VIEWPORT_H/4*3*I, 3000, BigFairy, stage4_splasher, -3-4I);
+		create_enemy1c(VIEWPORT_H/4*3*I, 3000, BigFairy, stage4_splasher, 3-4.0I);
+		create_enemy1c(VIEWPORT_W + VIEWPORT_H/4*3*I, 3000, BigFairy, stage4_splasher, -3-4.0I);
 	}
 	
 	FROM_TO(300, 450, 20) {
-		create_enemy1c(VIEWPORT_W*frand(), 200, Fairy, stage4_fodder, 3I);
+		create_enemy1c(VIEWPORT_W*frand(), 200, Fairy, stage4_fodder, 3.0I);
 	}
 	
 	FROM_TO(500, 550, 10) {
@@ -729,8 +729,8 @@ void stage4_events(void) {
 	}
 	
 	FROM_TO(600, 1400, 100) {
-		create_enemy3c(VIEWPORT_W/4.0 + VIEWPORT_W/2.0*(_i&1), 3000, BigFairy, stage4_cardbuster, VIEWPORT_W/6.0 + VIEWPORT_W/3.0*2*(_i&1)+100I,
-					VIEWPORT_W/4.0 + VIEWPORT_W/2.0*((_i+1)&1)+300I, VIEWPORT_W/2.0+VIEWPORT_H*I+200I);
+		create_enemy3c(VIEWPORT_W/4.0 + VIEWPORT_W/2.0*(_i&1), 3000, BigFairy, stage4_cardbuster, VIEWPORT_W/6.0 + VIEWPORT_W/3.0*2*(_i&1)+100.0I,
+					VIEWPORT_W/4.0 + VIEWPORT_W/2.0*((_i+1)&1)+300.0I, VIEWPORT_W/2.0+VIEWPORT_H*I+200.0I);
 	}
 	
 	AT(1800) {
@@ -739,32 +739,32 @@ void stage4_events(void) {
 	}
 	
 	FROM_TO(2000, 2600, 20)
-		create_enemy1c(300I*frand(), 200, Fairy, stage4_fodder, 2);
+		create_enemy1c(300.0I*frand(), 200, Fairy, stage4_fodder, 2);
 	
 	FROM_TO(2000, 2400, 200)
-		create_enemy1c(VIEWPORT_W/2+200-400*frand(), 1000, BigFairy, stage4_bigcircle, 2I);
+		create_enemy1c(VIEWPORT_W/2+200-400*frand(), 1000, BigFairy, stage4_bigcircle, 2.0I);
 		
 	FROM_TO(2600, 2800, 10)
-		create_enemy1c(20I+VIEWPORT_H/3*I*frand()+VIEWPORT_W, 100, Swirl, stage4_explosive, -3);
+		create_enemy1c(20.0I+VIEWPORT_H/3*I*frand()+VIEWPORT_W, 100, Swirl, stage4_explosive, -3);
 	
 	AT(3200)
 		global.boss = create_kurumi_mid();
 		
 	FROM_TO(3201, 3601, 10)
-		create_enemy1c(VIEWPORT_W*(_i&1)+VIEWPORT_H/2*I-300I*frand(), 200, Fairy, stage4_fodder, 2-4*(_i&1)+1I);
+		create_enemy1c(VIEWPORT_W*(_i&1)+VIEWPORT_H/2*I-300.0I*frand(), 200, Fairy, stage4_fodder, 2-4*(_i&1)+1.0I);
 	
 	FROM_TO(3500, 4000, 100)
-		create_enemy3c(VIEWPORT_W/4.0 + VIEWPORT_W/2.0*(_i&1), 1000, BigFairy, stage4_cardbuster, VIEWPORT_W/6.0*(_i&1)+100I,
-					VIEWPORT_W/4.0+VIEWPORT_W/2.0*((_i+1)&1)+300I, VIEWPORT_W/2.0-200I);
+		create_enemy3c(VIEWPORT_W/4.0 + VIEWPORT_W/2.0*(_i&1), 1000, BigFairy, stage4_cardbuster, VIEWPORT_W/6.0*(_i&1)+100.0I,
+					VIEWPORT_W/4.0+VIEWPORT_W/2.0*((_i+1)&1)+300.0I, VIEWPORT_W/2.0-200.0I);
 		
 	AT(3800)
-		create_enemy1c(VIEWPORT_W/2, 7000, BigFairy, stage4_supercard, 4I);
+		create_enemy1c(VIEWPORT_W/2, 7000, BigFairy, stage4_supercard, 4.0I);
 		
 	FROM_TO(4300, 4600, 95-10*global.diff)
 		create_enemy1c(VIEWPORT_W*(_i&1)+100*I, 200, Swirl, stage4_backfire, frand()*(1-2*(_i&1)));
 		
 	FROM_TO(4800, 5200, 10)
-		create_enemy1c(20I+I*VIEWPORT_H/3*frand()+VIEWPORT_W*(_i&1), 100, Swirl, stage4_explosive, (1-2*(_i&1))*3+I);
+		create_enemy1c(20.0I+I*VIEWPORT_H/3*frand()+VIEWPORT_W*(_i&1), 100, Swirl, stage4_explosive, (1-2*(_i&1))*3+I);
 		
 	AT(5300)
 		global.boss = create_kurumi();

--- a/src/stages/stage5_events.c
+++ b/src/stages/stage5_events.c
@@ -78,7 +78,7 @@ int stage5_lightburst(Enemy *e, int t) {
 		int i;
 		int c = 5+global.diff;
 		for(i = 0; i < c; i++) {
-			complex n = cexp(I*carg(global.plr.pos) + 2I*M_PI/c*i);
+			complex n = cexp(I*carg(global.plr.pos) + 2.0I*M_PI/c*i);
 			create_projectile2c("ball", e->pos + 50*n*cexp(-0.4I*_i*global.diff), rgb(0.3, 0, 0.7), asymptotic, 3*n, 3);
 		}
 	}
@@ -157,7 +157,7 @@ int stage5_miner(Enemy *e, int t) {
 	
 	FROM_TO(0, 600, 5-global.diff/2) {
 		tsrand_fill(2);
-		create_projectile1c("rice", e->pos + 20*cexp(2I*M_PI*afrand(0)), rgb(0,0,cabs(e->args[0])), linear, cexp(2I*M_PI*afrand(1)));
+		create_projectile1c("rice", e->pos + 20*cexp(2.0I*M_PI*afrand(0)), rgb(0,0,cabs(e->args[0])), linear, cexp(2.0I*M_PI*afrand(1)));
 	}
 	
 	return 1;
@@ -191,7 +191,7 @@ int stage5_explosion(Enemy *e, int t) {
 void iku_mid_intro(Boss *b, int t) {
 	TIMER(&t);
 	
-	b->pos += -1-7I+10*t*(cimag(b->pos)<-200);
+	b->pos += -1-7.0I+10*t*(cimag(b->pos)<-200);
 	
 	FROM_TO(90, 110, 10) {
 		create_enemy2c(b->pos, ENEMY_IMMUNE, Swirl, stage5_explosion, -2-0.5*_i+I*_i, _i == 1);
@@ -202,7 +202,7 @@ void iku_mid_intro(Boss *b, int t) {
 }
 
 Boss *create_iku_mid(void) {
-	Boss *b = create_boss("Bombs?", "iku", VIEWPORT_W+800I);
+	Boss *b = create_boss("Bombs?", "iku", VIEWPORT_W+800.0I);
 	
 	boss_add_attack(b, AT_SurvivalSpell, "Static Bombs", 16, 10, iku_mid_intro, NULL);
 	
@@ -224,8 +224,8 @@ int stage5_lightburst2(Enemy *e, int t) {
 		int c = 5+global.diff;
 		for(i = 0; i < c; i++) {
 			tsrand_fill(2);
-			complex n = cexp(I*carg(global.plr.pos-e->pos) + 2I*M_PI/c*i);
-			create_projectile2c("bigball", e->pos + 50*n*cexp(-1I*_i*global.diff), rgb(0.3, 0, 0.7+0.3*(_i&1)), asymptotic, 2.5*n+0.25*global.diff*afrand(0)*cexp(2I*M_PI*afrand(1)), 3);
+			complex n = cexp(I*carg(global.plr.pos-e->pos) + 2.0I*M_PI/c*i);
+			create_projectile2c("bigball", e->pos + 50*n*cexp(-1.0I*_i*global.diff), rgb(0.3, 0, 0.7+0.3*(_i&1)), asymptotic, 2.5*n+0.25*global.diff*afrand(0)*cexp(2.0I*M_PI*afrand(1)), 3);
 		}
 	}
 	
@@ -254,7 +254,7 @@ int stage5_superbullet(Enemy *e, int t) {
 }
 
 void iku_intro(Boss *b, int t) {
-	GO_TO(b, VIEWPORT_W/2+300I, 0.01);
+	GO_TO(b, VIEWPORT_W/2+300.0I, 0.01);
 	
 	if(t == 100)
 		global.dialog = stage5_boss_dialog();
@@ -266,7 +266,7 @@ void iku_bolts(Boss *b, int time) {
 	
 	FROM_TO(0, 400, 2) {
 		tsrand_fill(2);
-		create_projectile2c("bigball", VIEWPORT_W*afrand(0)-15I, rgb(1,0,0), accelerated, 1-2*afrand(1)+1.7I, -0.01I)->draw = ProjDrawSub;
+		create_projectile2c("bigball", VIEWPORT_W*afrand(0)-15.0I, rgb(1,0,0), accelerated, 1-2*afrand(1)+1.7I, -0.01I)->draw = ProjDrawSub;
 	}
 		
 	FROM_TO(60, 400, 50) {
@@ -277,22 +277,22 @@ void iku_bolts(Boss *b, int time) {
 	}
 	
 	FROM_TO(0, 70, 1)
-		GO_TO(b, 100+300I, 0.02);
+		GO_TO(b, 100+300.0I, 0.02);
 		
 	FROM_TO(100, 200, 1)
-		GO_TO(b, VIEWPORT_W/2+100I, 0.02);
+		GO_TO(b, VIEWPORT_W/2+100.0I, 0.02);
 		
 	FROM_TO(230, 300, 1)
-		GO_TO(b, VIEWPORT_W-100+300I, 0.02);
+		GO_TO(b, VIEWPORT_W-100+300.0I, 0.02);
 		
 	FROM_TO(330, 400, 1)
-		GO_TO(b, VIEWPORT_W/2+100I, 0.02);
+		GO_TO(b, VIEWPORT_W/2+100.0I, 0.02);
 		
 }
 
 void iku_atmospheric(Boss *b, int time) {
 	if(time < 0) {
-		GO_TO(b, VIEWPORT_W/2+200I, 0.06);
+		GO_TO(b, VIEWPORT_W/2+200.0I, 0.06);
 		return;
 	}
 	
@@ -326,7 +326,7 @@ void iku_bolts2(Boss *b, int time) {
 	
 	FROM_TO(0, 400, 2) {
 		tsrand_fill(2);
-		create_projectile2c("bigball", VIEWPORT_W*afrand(0)-15I, rgb(1,0,0), accelerated, 1-2*afrand(1)+1.7I, -0.01I)->draw = ProjDrawSub;
+		create_projectile2c("bigball", VIEWPORT_W*afrand(0)-15.0I, rgb(1,0,0), accelerated, 1-2*afrand(1)+1.7I, -0.01I)->draw = ProjDrawSub;
 	}
 		
 	FROM_TO(0, 400, 60)
@@ -337,10 +337,10 @@ void iku_bolts2(Boss *b, int time) {
 			create_projectile1c("plainball", b->pos, rgb(0.2,0,0.8), linear, cexp(0.1I*_i));
 	
 	FROM_TO(0, 70, 1)
-		GO_TO(b, 100+200I, 0.02);
+		GO_TO(b, 100+200.0I, 0.02);
 				
 	FROM_TO(230, 300, 1)
-		GO_TO(b, VIEWPORT_W-100+200I, 0.02);
+		GO_TO(b, VIEWPORT_W-100+200.0I, 0.02);
 		
 }
 
@@ -355,7 +355,7 @@ int lightning_slave(Enemy *e, int t) {
 	e->pos += e->args[0];
 	
 	FROM_TO(0,200,20)
-		e->args[0] *= cexp(2I*M_PI*frand());
+		e->args[0] *= cexp(2.0I*M_PI*frand());
 	
 	FROM_TO(0, 200, 3)
 		if(cabs(e->pos-global.plr.pos) > 60) {
@@ -376,14 +376,14 @@ void iku_lightning(Boss *b, int time) {
 	}
 	
 	if(time < 0) {
-		GO_TO(b, VIEWPORT_W/2.0+200I, 0.03);
+		GO_TO(b, VIEWPORT_W/2.0+200.0I, 0.03);
 		return;
 	}
 	
 	TIMER(&t);	
 			
 	FROM_TO(0, 100, 1) {
-		complex n = cexp(2I*M_PI*frand());
+		complex n = cexp(2.0I*M_PI*frand());
 		float l = 200*frand()+100;
 		float s = 4+_i*0.01;
 		create_particle2c("flare", b->pos+l*n, rgb(0.7,1,1), Shrink, timeout_linear, l/s, -s*n);
@@ -392,7 +392,7 @@ void iku_lightning(Boss *b, int time) {
 	AT(150) {
 		int i;
 		for(i = 0; i < global.diff+1; i++)
-			create_enemy1c(b->pos, ENEMY_IMMUNE, NULL, lightning_slave, 10*cexp(I*carg(global.plr.pos - b->pos)+2I*M_PI/(global.diff+1)*i));
+			create_enemy1c(b->pos, ENEMY_IMMUNE, NULL, lightning_slave, 10*cexp(I*carg(global.plr.pos - b->pos)+2.0I*M_PI/(global.diff+1)*i));
 	}
 }
 
@@ -402,7 +402,7 @@ void iku_bolts3(Boss *b, int time) {
 	
 	FROM_TO(0, 400, 2) {
 		tsrand_fill(2);
-		create_projectile2c("bigball", VIEWPORT_W*afrand(0)-15I, rgb(1,0,0), accelerated, 1-2*afrand(1)+1.8I, -0.01I)->draw = ProjDrawSub;
+		create_projectile2c("bigball", VIEWPORT_W*afrand(0)-15.0I, rgb(1,0,0), accelerated, 1-2*afrand(1)+1.8I, -0.01I)->draw = ProjDrawSub;
 	}
 		
 	FROM_TO(60, 400, 60) {
@@ -418,10 +418,10 @@ void iku_bolts3(Boss *b, int time) {
 			create_projectile1c("plainball", b->pos, rgb(0.2,0,0.8), linear, cexp(0.1I*_i));
 	
 	FROM_TO(0, 70, 1)
-		GO_TO(b, 100+200I, 0.02);
+		GO_TO(b, 100+200.0I, 0.02);
 				
 	FROM_TO(230, 300, 1)
-		GO_TO(b, VIEWPORT_W-100+200I, 0.02);
+		GO_TO(b, VIEWPORT_W-100+200.0I, 0.02);
 		
 }
 
@@ -441,7 +441,7 @@ complex cathode_laser(Laser *l, float t) {
 
 void iku_cathode(Boss *b, int t) {
 	if(t < 0) {
-		GO_TO(b, VIEWPORT_W/2+200I, 0.02);
+		GO_TO(b, VIEWPORT_W/2+200.0I, 0.02);
 		return;
 	}
 	
@@ -452,15 +452,15 @@ void iku_cathode(Boss *b, int t) {
 		int c = 5+global.diff;
 		
 		for(i = 0; i < c; i++) {
-			create_projectile2c("bigball", b->pos, rgb(0.2, 0.4, 1), induction_bullet, 2*cexp(2I*M_PI*frand()), 0.01*I*(1-2*(_i&1)))->draw = ProjDrawAdd;
-			create_lasercurve2c(b->pos, 60, 200, rgb(0.4, 1, 1), cathode_laser, 2*cexp(2I*M_PI*M_PI*frand()), 0.015*I*(1-2*(_i&1)));
+			create_projectile2c("bigball", b->pos, rgb(0.2, 0.4, 1), induction_bullet, 2*cexp(2.0I*M_PI*frand()), 0.01*I*(1-2*(_i&1)))->draw = ProjDrawAdd;
+			create_lasercurve2c(b->pos, 60, 200, rgb(0.4, 1, 1), cathode_laser, 2*cexp(2.0I*M_PI*M_PI*frand()), 0.015*I*(1-2*(_i&1)));
 		}
 	}
 }
 
 void iku_induction(Boss *b, int t) {
 	if(t < 0) {
-		GO_TO(b, VIEWPORT_W/2+200I, 0.02);
+		GO_TO(b, VIEWPORT_W/2+200.0I, 0.02);
 		return;
 	}
 		
@@ -471,7 +471,7 @@ void iku_induction(Boss *b, int t) {
 		int c = 5+global.diff;
 		for(i = 0; i < c; i++) {
 			for(j = 0; j < 2; j++)
-				create_projectile2c("ball", b->pos, rgb(0, 1, 1), induction_bullet, 2*cexp(2I*M_PI/c*i+I*M_PI/2+0.6I*(_i/6)), (0.01+0.001*global.diff)*I*(1-2*j))->draw = ProjDrawAdd;			
+				create_projectile2c("ball", b->pos, rgb(0, 1, 1), induction_bullet, 2*cexp(2.0I*M_PI/c*i+I*M_PI/2+0.6I*(_i/6)), (0.01+0.001*global.diff)*I*(1-2*j))->draw = ProjDrawAdd;			
 		}
 		
 	}
@@ -480,7 +480,7 @@ void iku_induction(Boss *b, int t) {
 void iku_spell_bg(Boss *b, int t);
 
 Boss *create_iku(void) {
-	Boss *b = create_boss("Nagae Iku", "iku", VIEWPORT_W/2-200I);
+	Boss *b = create_boss("Nagae Iku", "iku", VIEWPORT_W/2-200.0I);
 	
 	boss_add_attack(b, AT_Move, "Introduction", 3, 0, iku_intro, NULL);
 	boss_add_attack(b, AT_Normal, "Bolts1", 20, 20000, iku_bolts, NULL);
@@ -498,37 +498,37 @@ void stage5_events(void) {
 	TIMER(&global.timer);
 			
 	FROM_TO(60, 120, 10)
-		create_enemy1c(VIEWPORT_W+70I+50*_i*I, 300, Fairy, stage5_greeter, -3);
+		create_enemy1c(VIEWPORT_W+70.0I+50*_i*I, 300, Fairy, stage5_greeter, -3);
 	
 	FROM_TO(270, 320, 25)
-		create_enemy1c(VIEWPORT_W/4+VIEWPORT_W/2*_i, 2000, BigFairy, stage5_lightburst, 2I);
+		create_enemy1c(VIEWPORT_W/4+VIEWPORT_W/2*_i, 2000, BigFairy, stage5_lightburst, 2.0I);
 		
 	FROM_TO(500, 600, 10) {
 		tsrand_fill(2);
-		create_enemy3c(200I*afrand(0), 500, Swirl, stage5_swirl, 4+I, 70+20*afrand(1)+200I, cexp(-0.05I));
+		create_enemy3c(200.0I*afrand(0), 500, Swirl, stage5_swirl, 4+I, 70+20*afrand(1)+200.0I, cexp(-0.05I));
 	}
 		
 	FROM_TO(700, 800, 10) {
 		tsrand_fill(3);
-		create_enemy3c(VIEWPORT_W+200I*afrand(0), 500, Swirl, stage5_swirl, -4+afrand(1)*I, 70+20*afrand(2)+200I, cexp(0.05I));
+		create_enemy3c(VIEWPORT_W+200.0I*afrand(0), 500, Swirl, stage5_swirl, -4+afrand(1)*I, 70+20*afrand(2)+200.0I, cexp(0.05I));
 	}
 		
 	FROM_TO(870, 1000, 50)
 		create_enemy1c(VIEWPORT_W/4+VIEWPORT_W/2*(_i&1), 2000, BigFairy, stage5_limiter, I);
 		
 	AT(1000)
-		create_enemy1c(VIEWPORT_W/2, 9000, BigFairy, stage5_laserfairy, 2I);
+		create_enemy1c(VIEWPORT_W/2, 9000, BigFairy, stage5_laserfairy, 2.0I);
 		
 	FROM_TO(1900, 2200, 40) {
 		tsrand_fill(2);
-		create_enemy1c(VIEWPORT_W+200I*afrand(0), 500, Swirl, stage5_miner, -3+2I*afrand(1));
+		create_enemy1c(VIEWPORT_W+200.0I*afrand(0), 500, Swirl, stage5_miner, -3+2.0I*afrand(1));
 	}
 	
 	FROM_TO(1500, 2400, 80)
-		create_enemy1c(VIEWPORT_W*(_i&1)+100I, 300, Fairy, stage5_greeter, 3-6*(_i&1));
+		create_enemy1c(VIEWPORT_W*(_i&1)+100.0I, 300, Fairy, stage5_greeter, 3-6*(_i&1));
 		
 	FROM_TO(2200, 2600, 40)
-		create_enemy1c(VIEWPORT_W/10*_i, 200, Swirl, stage5_miner, 3I);
+		create_enemy1c(VIEWPORT_W/10*_i, 200, Swirl, stage5_miner, 3.0I);
 		
 	AT(2900)
 		global.boss = create_iku_mid();
@@ -537,19 +537,19 @@ void stage5_events(void) {
 		global.dialog = stage5_post_mid_dialog();
 		
 	FROM_TO(3000, 3200, 100)
-		create_enemy1c(VIEWPORT_W/2 + VIEWPORT_W/6*(1-2*(_i&1)), 2000, BigFairy, stage5_lightburst2, -1+2*(_i&1) + 2I);
+		create_enemy1c(VIEWPORT_W/2 + VIEWPORT_W/6*(1-2*(_i&1)), 2000, BigFairy, stage5_lightburst2, -1+2*(_i&1) + 2.0I);
 		
 	FROM_TO(3300, 4000, 50)
-		create_enemy1c(200I+VIEWPORT_W*(_i&1), 1500, Fairy, stage5_superbullet, 3-6*(_i&1));
+		create_enemy1c(200.0I+VIEWPORT_W*(_i&1), 1500, Fairy, stage5_superbullet, 3-6*(_i&1));
 	
 	AT(3400) {
-		create_enemy2c(VIEWPORT_W/4, 6000, BigFairy, stage5_laserfairy, 2I, 1);
-		create_enemy2c(VIEWPORT_W/4*3, 6000, BigFairy, stage5_laserfairy, 2I, 1);
+		create_enemy2c(VIEWPORT_W/4, 6000, BigFairy, stage5_laserfairy, 2.0I, 1);
+		create_enemy2c(VIEWPORT_W/4*3, 6000, BigFairy, stage5_laserfairy, 2.0I, 1);
 	}
 	
 	FROM_TO(4200, 5000, 20) {
 		float f = frand();
-		create_enemy3c(VIEWPORT_W/2, 400, Swirl, stage5_swirl, 2*cexp(I*M_PI*f)+I, 60 + 100I, cexp(0.01I*(1-2*(f<0.5))));
+		create_enemy3c(VIEWPORT_W/2, 400, Swirl, stage5_swirl, 2*cexp(I*M_PI*f)+I, 60 + 100.0I, cexp(0.01I*(1-2*(f<0.5))));
 	}
 	
 	AT(5300)

--- a/src/stages/stage6_events.c
+++ b/src/stages/stage6_events.c
@@ -49,7 +49,7 @@ int stage6_hacker(Enemy *e, int t) {
 		int i;
 		for(i = 0; i < 6; i++) {
 			complex n = sin(_i*0.2)*cexp(I*0.3*(i/2-1))*(1-2*(i&1));
-			create_projectile1c("wave", e->pos + 120*n, rgb(1.0, 0.2-0.01*_i, 0.0), linear, (0.25-0.5*frand())*global.diff+creal(n)+2I);
+			create_projectile1c("wave", e->pos + 120*n, rgb(1.0, 0.2-0.01*_i, 0.0), linear, (0.25-0.5*frand())*global.diff+creal(n)+2.0I);
 		}
 	}
 	
@@ -72,7 +72,7 @@ int stage6_side(Enemy *e, int t) {
 		int i;
 		int c = 15+10*global.diff;
 		for(i = 0; i < c; i++) {
-			create_projectile2c("rice", e->pos+5*(i/2)*e->args[1], rgb(0, 0.5, 1), accelerated, (1I-2I*(i&1))*(0.7+0.2*global.diff), 0.001*(i/2)*e->args[1]);
+			create_projectile2c("rice", e->pos+5*(i/2)*e->args[1], rgb(0, 0.5, 1), accelerated, (1.0I-2.0I*(i&1))*(0.7+0.2*global.diff), 0.001*(i/2)*e->args[1]);
 		}
 	}
 	
@@ -147,7 +147,7 @@ void Scythe(Enemy *e, int t) {
 	p->angle = creal(e->args[1]);
 	e->args[1] += cimag(e->args[1]);
 	
-	create_particle2c("flare", e->pos+100*creal(e->args[2])*frand()*cexp(2I*M_PI*frand()), rgb(1,1,0.6), GrowFadeAdd, timeout_linear, 60, -I+1);
+	create_particle2c("flare", e->pos+100*creal(e->args[2])*frand()*cexp(2.0I*M_PI*frand()), rgb(1,1,0.6), GrowFadeAdd, timeout_linear, 60, -I+1);
 }
 
 int scythe_intro(Enemy *e, int t) {
@@ -156,7 +156,7 @@ int scythe_intro(Enemy *e, int t) {
 	
 	TIMER(&t);
 	
-	GO_TO(e,VIEWPORT_W/2+200I, 0.05);
+	GO_TO(e,VIEWPORT_W/2+200.0I, 0.05);
 	
 	
 	FROM_TO(60, 119, 1) {
@@ -169,10 +169,10 @@ int scythe_intro(Enemy *e, int t) {
 
 void elly_intro(Boss *b, int t) {
 	TIMER(&t);
-	GO_TO(b, VIEWPORT_W/2+200I, 0.01);
+	GO_TO(b, VIEWPORT_W/2+200.0I, 0.01);
 	
 	AT(200) {
-		create_enemy3c(VIEWPORT_W+200+200I, ENEMY_IMMUNE, Scythe, scythe_intro, 0, 1+0.2I, 1);
+		create_enemy3c(VIEWPORT_W+200+200.0I, ENEMY_IMMUNE, Scythe, scythe_intro, 0, 1+0.2I, 1);
 	}
 	
 	AT(300)
@@ -185,14 +185,14 @@ int scythe_infinity(Enemy *e, int t) {
 	
 	TIMER(&t);
 	FROM_TO(0, 40, 1) {
-		GO_TO(e, VIEWPORT_W/2+200I, 0.01);
+		GO_TO(e, VIEWPORT_W/2+200.0I, 0.01);
 		e->args[2] = min(0.8, creal(e->args[2])+0.0003*t*t);
 		e->args[1] = creal(e->args[1]) + I*min(0.2, cimag(e->args[1])+0.0001*t*t);
 	}
 	
 	FROM_TO(40, 3000, 1) {
 		float w = min(0.15, 0.0001*(t-40));
-		e->pos = VIEWPORT_W/2 + 200I + 200*cos(w*(t-40)+M_PI/2.0) + I*80*sin(creal(e->args[0])*w*(t-40));
+		e->pos = VIEWPORT_W/2 + 200.0I + 200*cos(w*(t-40)+M_PI/2.0) + I*80*sin(creal(e->args[0])*w*(t-40));
 		
 		create_projectile2c("ball", e->pos+80*cexp(I*creal(e->args[1])), rgb(cos(creal(e->args[1])), sin(creal(e->args[1])), cos(creal(e->args[1])+2.1)), asymptotic, (1+0.2*global.diff)*cexp(I*creal(e->args[1])), 3);
 	}
@@ -207,7 +207,7 @@ int scythe_reset(Enemy *e, int t) {
 	if(t == 1)
 		e->args[1] = fmod(creal(e->args[1]), 2*M_PI) + I*cimag(e->args[1]);
 	
-	GO_TO(e, VIEWPORT_W/2.0+200I, 0.02);
+	GO_TO(e, VIEWPORT_W/2.0+200.0I, 0.02);
 	e->args[2] = max(0.6, creal(e->args[2])-0.01*t);
 	e->args[1] += (0.19-creal(e->args[1]))*0.05;
 	e->args[1] = creal(e->args[1]) + I*0.9*cimag(e->args[1]);
@@ -340,7 +340,7 @@ void elly_maxwell(Boss *b, int t) {
 	TIMER(&t);
 	
 	FROM_TO(40, 159, 5)
-		create_laser(b->pos, 200, 10000, rgb(0,0.2,1), maxwell_laser, maxwell_laser_logic, cexp(2I*M_PI/24*_i)*VIEWPORT_H*0.005, 200+15I, 0, 0);
+		create_laser(b->pos, 200, 10000, rgb(0,0.2,1), maxwell_laser, maxwell_laser_logic, cexp(2.0I*M_PI/24*_i)*VIEWPORT_H*0.005, 200+15.0I, 0, 0);
 	
 }
 
@@ -364,10 +364,10 @@ void Baryon(Enemy *e, int t) {
 	glPopMatrix();
 	glDisable(GL_TEXTURE_2D);
 	
-// 	create_particle2c("flare", e->pos+40*frand()*cexp(2I*M_PI*frand()), rgb(0, 1, 1), GrowFadeAdd, timeout_linear, 50, 1-I);
+// 	create_particle2c("flare", e->pos+40*frand()*cexp(2.0I*M_PI*frand()), rgb(0, 1, 1), GrowFadeAdd, timeout_linear, 50, 1-I);
 	
 	if(!(t % 10))
-		create_particle1c("stain", e->pos+10*frand()*cexp(2I*M_PI*frand()), rgb(0, 1, 0.7), FadeAdd, timeout, 50)->angle = 2*M_PI*frand();
+		create_particle1c("stain", e->pos+10*frand()*cexp(2.0I*M_PI*frand()), rgb(0, 1, 0.7), FadeAdd, timeout, 50)->angle = 2*M_PI*frand();
 }
 
 void BaryonCenter(Enemy *e, int t) {
@@ -403,8 +403,8 @@ void BaryonCenter(Enemy *e, int t) {
 		
 	}
 	glDisable(GL_TEXTURE_2D);
-	create_particle2c("flare", e->pos+40*frand()*cexp(2I*M_PI*frand()), rgb(0, 1, 1), GrowFadeAdd, timeout_linear, 50, 1-I);
-	create_particle1c("stain", e->pos+40*frand()*cexp(2I*M_PI*frand()), rgb(0, 1, 0.2), FadeAdd, timeout, 50)->angle = 2*M_PI*frand();
+	create_particle2c("flare", e->pos+40*frand()*cexp(2.0I*M_PI*frand()), rgb(0, 1, 1), GrowFadeAdd, timeout_linear, 50, 1-I);
+	create_particle1c("stain", e->pos+40*frand()*cexp(2.0I*M_PI*frand()), rgb(0, 1, 0.2), FadeAdd, timeout, 50)->angle = 2*M_PI*frand();
 }
 
 int baryon_unfold(Enemy *e, int t) {
@@ -461,7 +461,7 @@ void elly_unbound(Boss *b, int t) {
 		int i;
 		Enemy *e, *last = NULL, *first, *middle;
 		for(i = 0; i < 6; i++) {
-			e = create_enemy3c(b->pos, ENEMY_IMMUNE, Baryon, baryon_unfold, 1.5*cexp(2I*M_PI/6*i), i != 0 ? add_ref(last) : 0, i);
+			e = create_enemy3c(b->pos, ENEMY_IMMUNE, Baryon, baryon_unfold, 1.5*cexp(2.0I*M_PI/6*i), i != 0 ? add_ref(last) : 0, i);
 			if(i == 0)
 				first = e;
 			else if(i == 3)
@@ -510,9 +510,9 @@ int baryon_eigenstate(Enemy *e, int t) {
 		int c = 9;
 		
 		for(i = 0; i < c; i++) {
-			complex n = cexp(2I*_i+I*M_PI/2+I*creal(e->args[2]));
+			complex n = cexp(2.0I*_i+I*M_PI/2+I*creal(e->args[2]));
 			for(j = 0; j < 3; j++)
-				create_projectile4c("plainball", e->pos + 60*cexp(2I*M_PI/c*i), rgb(j == 0, j == 1, j == 2), eigenstate_proj, 1*n, 1, 60, 0.6I*n*(j-1)*cexp(0.4I-0.1I*global.diff))->draw = ProjDrawAdd;
+				create_projectile4c("plainball", e->pos + 60*cexp(2.0I*M_PI/c*i), rgb(j == 0, j == 1, j == 2), eigenstate_proj, 1*n, 1, 60, 0.6I*n*(j-1)*cexp(0.4I-0.1I*global.diff))->draw = ProjDrawAdd;
 			
 		}
 	}
@@ -560,15 +560,15 @@ void elly_baryonattack(Boss *b, int t) {
 
 int baryon_ricci(Enemy *e, int t) {
 	if(!creal(e->args[2]) || creal(e->args[2]) > 2) {
-		GO_TO(e, creal(global.boss->pos) + creal(e->pos0-global.boss->pos)*1.5+40I, 0.02);
+		GO_TO(e, creal(global.boss->pos) + creal(e->pos0-global.boss->pos)*1.5+40.0I, 0.02);
 	} else {
 		TIMER(&t);
 		FROM_TO(200, 400, 1) {
-			GO_TO(e, creal(global.boss->pos) + creal(e->pos0-global.boss->pos)*1.8 + 230I, 0.05);
+			GO_TO(e, creal(global.boss->pos) + creal(e->pos0-global.boss->pos)*1.8 + 230.0I, 0.05);
 		}
 		
 		FROM_TO_INT(300, 10000, 100, 200, 1)
-			GO_TO(e, creal(global.boss->pos) + creal(e->pos0-global.boss->pos)*1.8 + 230I + 200I*(_i&1), 0.02);
+			GO_TO(e, creal(global.boss->pos) + creal(e->pos0-global.boss->pos)*1.8 + 230.0I + 200.0I*(_i&1), 0.02);
 	}	
 	
 	return 1;
@@ -608,7 +608,7 @@ void elly_ricci(Boss *b, int t) {
 		int i;
 		int c = 6 + global.diff;
 		for(i = 0; i < c*2; i++)
-			create_projectile2c("plainball", fmod(VIEWPORT_W/(float)c*(i/2),VIEWPORT_W)+VIEWPORT_H*I*(i&1), rgb(0.3+0.7*(i&1), 1-0.7*(i&1), 0), ricci_proj, I-2I*(i&1), 200-t)->draw = ProjDrawAdd;
+			create_projectile2c("plainball", fmod(VIEWPORT_W/(float)c*(i/2),VIEWPORT_W)+VIEWPORT_H*I*(i&1), rgb(0.3+0.7*(i&1), 1-0.7*(i&1), 0), ricci_proj, I-2.0I*(i&1), 200-t)->draw = ProjDrawAdd;
 			
 	}
 }
@@ -656,10 +656,10 @@ int baryon_lhc(Enemy *e, int t) {
 	TIMER(&t1);	
 	
 	AT(1) {
-		e->args[3] = 100I+400I*((t/400)&1);
+		e->args[3] = 100.0I+400.0I*((t/400)&1);
 	
 		if(g == 2 || g == 5) {
-			create_laser(e->pos, 200, 300, rgb(0.1+0.9*(g>3),0,1-0.9*(g>3)), las_linear, lhc_laser_logic, (1-2*(g>3))*VIEWPORT_W*0.005, 200+30I, add_ref(e), 0);
+			create_laser(e->pos, 200, 300, rgb(0.1+0.9*(g>3),0,1-0.9*(g>3)), las_linear, lhc_laser_logic, (1-2*(g>3))*VIEWPORT_W*0.005, 200+30.0I, add_ref(e), 0);
 		}
 	}
 		
@@ -679,21 +679,21 @@ void elly_lhc(Boss *b, int t) {
 	FROM_TO(280, 10000, 400) {
 		int i;
 		int c = 30+10*global.diff;
-		complex pos = VIEWPORT_W/2 + 100I+400I*((t/400)&1);
+		complex pos = VIEWPORT_W/2 + 100.0I+400.0I*((t/400)&1);
 		
 		global.shake_view = 16;		
 				
 		for(i = 0; i < c; i++) {
-			complex v = 3*cexp(2I*M_PI*frand());
+			complex v = 3*cexp(2.0I*M_PI*frand());
 			tsrand_fill(4);
 			create_lasercurve2c(pos, 70+20*global.diff, 300, rgb(1, 1, 1), las_accel, v, 0.02*frand()*copysign(1,creal(v)))->width=15;
-			create_projectile1c("soul", pos, rgb(0.4, 0, 1.0), linear, (1+2.5*afrand(0))*cexp(2I*M_PI*afrand(1)))->draw = ProjDrawAdd;
-			create_projectile1c("bigball", pos, rgb(1, 0, 0.4), linear, (1+2.5*afrand(2))*cexp(2I*M_PI*afrand(3)))->draw = ProjDrawAdd;
+			create_projectile1c("soul", pos, rgb(0.4, 0, 1.0), linear, (1+2.5*afrand(0))*cexp(2.0I*M_PI*afrand(1)))->draw = ProjDrawAdd;
+			create_projectile1c("bigball", pos, rgb(1, 0, 0.4), linear, (1+2.5*afrand(2))*cexp(2.0I*M_PI*afrand(3)))->draw = ProjDrawAdd;
 		}
 	}
 	
 	FROM_TO(0, 100000,7-global.diff)
-		create_projectile2c("ball", b->pos, rgb(0, 0.4,1), asymptotic, cexp(2I*_i), 3)->draw = ProjDrawAdd;
+		create_projectile2c("ball", b->pos, rgb(0, 0.4,1), asymptotic, cexp(2.0I*_i), 3)->draw = ProjDrawAdd;
 	
 	FROM_TO(300, 10000, 400) {
 		global.shake_view = 0;
@@ -729,13 +729,13 @@ void elly_baryon_explode(Boss *b, int t) {
 			
 	FROM_TO(0, 200, 1) {
 		tsrand_fill(2);
-		petal_explosion(1, b->pos + 100*afrand(0)*cexp(2I*M_PI*afrand(1)));
+		petal_explosion(1, b->pos + 100*afrand(0)*cexp(2.0I*M_PI*afrand(1)));
 	}
 	
 	AT(200) {
 		tsrand_fill(2);
 		global.shake_view = 10;
-		petal_explosion(100, b->pos + 100*afrand(0)*cexp(2I*M_PI*afrand(1)));
+		petal_explosion(100, b->pos + 100*afrand(0)*cexp(2.0I*M_PI*afrand(1)));
 		killall(global.enemies);
 	}
 	
@@ -825,7 +825,7 @@ void elly_theory(Boss *b, int time) {
 	if(time == EVENT_BIRTH)
 		global.shake_view = 10;
 	if(time < 20)
-		GO_TO(b, VIEWPORT_W/2+300I, 0.05);
+		GO_TO(b, VIEWPORT_W/2+300.0I, 0.05);
 	if(time == 0)
 		global.shake_view = 0;
 	
@@ -834,13 +834,13 @@ void elly_theory(Boss *b, int time) {
 	FROM_TO(0, 500, 10)
 		for(i = 0; i < 3; i++) {
 			tsrand_fill(5);
-			create_particle2c("stain", b->pos+80*afrand(0)*cexp(2I*M_PI*afrand(1)), rgba(1-afrand(2),0.8,0.5,1), FadeAdd, timeout, 60, 1+3*afrand(3))->angle = 2*M_PI*afrand(4);
+			create_particle2c("stain", b->pos+80*afrand(0)*cexp(2.0I*M_PI*afrand(1)), rgba(1-afrand(2),0.8,0.5,1), FadeAdd, timeout, 60, 1+3*afrand(3))->angle = 2*M_PI*afrand(4);
 		}
 	
 	FROM_TO(20, 70, 30-global.diff) {
 		int c = 20+2*global.diff;
 		for(i = 0; i < c; i++) {
-			complex n = cexp(2I*M_PI/c*i);
+			complex n = cexp(2.0I*M_PI/c*i);
 			create_projectile2c("soul", b->pos, rgb(0.2, 0, 0.9), accelerated, n, (0.01+0.002*global.diff)*n+0.01I*n*(1-2*(_i&1)))->draw = ProjDrawAdd;
 		}
 	}
@@ -855,7 +855,7 @@ void elly_theory(Boss *b, int time) {
 	}
 	
 	FROM_TO(250, 299, 10) {
-		create_enemy3c(b->pos, ENEMY_IMMUNE, Scythe, scythe_theory, cexp(2I*M_PI/5*_i+I*(time/500)), 0.2I, 1);
+		create_enemy3c(b->pos, ENEMY_IMMUNE, Scythe, scythe_theory, cexp(2.0I*M_PI/5*_i+I*(time/500)), 0.2I, 1);
 	}
 	
 }
@@ -879,7 +879,7 @@ void elly_spellbg_modern(Boss *b, int t) {
 }
 
 Boss *create_elly(void) {
-	Boss *b = create_boss("Elly", "elly", -200I);
+	Boss *b = create_boss("Elly", "elly", -200.0I);
 	
 	boss_add_attack(b, AT_Move, "Catch the Scythe", 6, 0, elly_intro, NULL);
 	boss_add_attack(b, AT_Normal, "Frequency", 30, 26000, elly_frequency, NULL);
@@ -906,24 +906,24 @@ void stage6_events(void) {
 // 		global.timer = 3800;
 	
 	AT(100)
-		create_enemy1c(VIEWPORT_W/2, 6000, BigFairy, stage6_hacker, 2I);
+		create_enemy1c(VIEWPORT_W/2, 6000, BigFairy, stage6_hacker, 2.0I);
 		
 	FROM_TO(500, 700, 10)
-		create_enemy2c(VIEWPORT_W*(_i&1), 2000, Fairy, stage6_side, 2I+0.1*(1-2*(_i&1)),1-2*(_i&1));
+		create_enemy2c(VIEWPORT_W*(_i&1), 2000, Fairy, stage6_side, 2.0I+0.1*(1-2*(_i&1)),1-2*(_i&1));
 		
 	FROM_TO(720, 940, 10) {
 		complex p = VIEWPORT_W/2+(1-2*(_i&1))*20*(_i%10);
-		create_enemy2c(p, 2000, Fairy, stage6_side, 2I+1*(1-2*(_i&1)),I*cexp(I*carg(global.plr.pos-p))*(1-2*(_i&1)));
+		create_enemy2c(p, 2000, Fairy, stage6_side, 2.0I+1*(1-2*(_i&1)),I*cexp(I*carg(global.plr.pos-p))*(1-2*(_i&1)));
 	}
 	
 	FROM_TO(1380, 1660, 20)
-		create_enemy2c(200I, 600, Fairy, stage6_flowermine, 2*cexp(0.5I*M_PI/9*_i)+1, 0);
+		create_enemy2c(200.0I, 600, Fairy, stage6_flowermine, 2*cexp(0.5I*M_PI/9*_i)+1, 0);
 		
 	FROM_TO(1600, 2000, 20)
-		create_enemy3c(VIEWPORT_W/2, 600, Fairy, stage6_flowermine, 2*cexp(0.5I*M_PI/9*_i+I*M_PI/2)+1I, VIEWPORT_H/2*I+VIEWPORT_W, 1);
+		create_enemy3c(VIEWPORT_W/2, 600, Fairy, stage6_flowermine, 2*cexp(0.5I*M_PI/9*_i+I*M_PI/2)+1.0I, VIEWPORT_H/2*I+VIEWPORT_W, 1);
 	
 	AT(2300)
-		create_enemy3c(200I-200, ENEMY_IMMUNE, Scythe, scythe_mid, 1, 0.2I, 1);
+		create_enemy3c(200.0I-200, ENEMY_IMMUNE, Scythe, scythe_mid, 1, 0.2I, 1);
 		
 	AT(3800)
 		global.boss = create_elly();


### PR DESCRIPTION
Because of some compilers don't support complex integer arithmetic (which is GCC extension), and source code of taisei contains such numbers only in constants, I decided to replace every such constant to floating-point one, as arithmetic really is floating-point in many cases (contains divisions, floating-point numbers in expressions, etc.).

This may help to achieve portability to platforms for which gcc or replacing compiler does not offer integral arithmetic option (and did helped so for E2K platform).

Build was tested and no strange behavior or errors were detected.